### PR TITLE
Enable ast based chunking for typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.7.0
+
+### Breaking Changes
+
+- Chunking version 3, requires index rebuild
+
+### Added
+
+- AST based chunking is now default for typescript projects using `ts-morph`
+- Cursory tests
+
+### Changed
+
+- Move existing incremental indexing tests from .ts to .txt extension
+
 ## v0.6.0
 
 ### Added
@@ -19,8 +34,8 @@
 ### Changed
 
 - CLI is now bundled with tsup for faster cold start and smaller install
-- [If daemon bundled] Daemon is now bundled with tsup
-- Internal workspace packages [are now private | remain published for daemon's dependency tree]
+- Daemon is now bundled with tsup
+- Internal workspace packages are now private / remain published for daemon's dependency tree
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,25 @@
 
 ### Breaking Changes
 
-- Chunking version 3, requires index rebuild
+- Chunking format updated (version 3). Existing indexes are incompatible
+  and must be rebuilt with `prsense index . --force`.
 
 ### Added
 
-- AST based chunking is now default for typescript projects using `ts-morph`
-- Cursory tests
+- TypeScript files (`.ts`, `.tsx`) are now chunked along semantic boundaries
+  — functions, classes, interfaces, type aliases, top-level declarations —
+  rather than fixed character windows. Improves retrieval relevance for
+  symbol-level queries. Other file types continue to use character-based
+  chunking.
 
-### Changed
+### Fixed
 
-- Move existing incremental indexing tests from .ts to .txt extension
+- Chunker no longer drops top-level control-flow statements (`if`, `for`,
+  `try`, etc.), preventing silent content loss in entry-point files.
+- `export default function` and `export default class` declarations are
+  now correctly indexed.
+- Oversized declarations are split safely without exceeding configured
+  character limits.
 
 ## v0.6.1
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,7 +50,8 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@google/generative-ai": "^0.24.1",
     "got": "^11.8.6",
-    "dotenv": "^17.2.3"
+    "dotenv": "^17.2.3",
+    "ts-morph": "^28.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -50,5 +50,6 @@ export default defineConfig({
     "@google/generative-ai",
     "got",
     "dotenv",
+    "ts-morph",
   ],
 });

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -34,7 +34,8 @@
     "openai": "^6.16.0",
     "@anthropic-ai/sdk": "^0.71.2",
     "@google/generative-ai": "^0.24.1",
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.2",
+    "ts-morph": "^28.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",

--- a/apps/daemon/tsup.config.ts
+++ b/apps/daemon/tsup.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
     "@anthropic-ai/sdk",
     "@google/generative-ai",
     "yaml",
+    "ts-morph",
   ],
 
   banner: { js: "#!/usr/bin/env node" },

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -24,7 +24,8 @@
     "@gitbeaker/rest": "^43.8.0",
     "@octokit/rest": "^22.0.1",
     "@prsense/core": "workspace:*",
-    "pg": "^8.17.1"
+    "pg": "^8.17.1",
+    "ts-morph": "^28.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",

--- a/packages/context/src/chunking/__tests__/compositeChunker.test.ts
+++ b/packages/context/src/chunking/__tests__/compositeChunker.test.ts
@@ -1,0 +1,27 @@
+// packages/context/src/chunking/__tests__/compositeChunker.test.ts
+
+import { createCompositeChunker } from "../compositeChunker.js";
+
+describe("createCompositeChunker", () => {
+  const chunker = createCompositeChunker({
+    char: { maxChars: 1000, overlapChars: 200 },
+  });
+
+  it("routes .ts files to the TypeScript chunker", () => {
+    const chunks = chunker.chunk({
+      content: "export function foo() { return 1; }",
+      source: { kind: "file", path: "foo.ts" },
+    });
+    const symbols = chunks.flatMap((c) => c.metadata?.symbols ?? []);
+    expect(symbols).toContain("foo");
+  });
+
+  it("routes non-TS files to the char chunker", () => {
+    const chunks = chunker.chunk({
+      content: "package main\nfunc foo() {}",
+      source: { kind: "file", path: "main.go" },
+    });
+    // Char chunker doesn't extract symbols.
+    expect(chunks[0]?.metadata?.symbols).toBeUndefined();
+  });
+});

--- a/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
+++ b/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
@@ -151,4 +151,27 @@ function tiny2() { return 2; }
     // — not per-symbol granularity. Per-symbol export tracking is a future concern.
     expect(merged?.metadata?.exported).toBe(true);
   });
+
+  it("falls back to a single chunk when no chunkable statements are extracted", () => {
+    // Content that parses to a SourceFile but has no top-level chunkable
+    // declarations — just stray tokens.
+    const content = "}{ >>> not really valid <<< )(";
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "garbage.ts" },
+    });
+
+    // Content must not be lost — at least one chunk should exist.
+    expect(chunks.length).toBeGreaterThan(0);
+    // The fallback chunk should contain the original content.
+    expect(chunks[0]?.content).toContain("not really valid");
+  });
+
+  it("produces no chunks for genuinely empty content", () => {
+    const chunks = chunker.chunk({
+      content: "   \n  \n  ",
+      source: { kind: "file", path: "empty.ts" },
+    });
+    expect(chunks.length).toBe(0);
+  });
 });

--- a/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
+++ b/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
@@ -174,4 +174,33 @@ function tiny2() { return 2; }
     });
     expect(chunks.length).toBe(0);
   });
+
+  it("splits an oversized single-line expression-bodied arrow without truncation", () => {
+    const chunker = createTypescriptChunker({
+      targetMinChars: 100,
+      targetMaxChars: 500,
+      hardMinChars: 50,
+      hardMaxChars: 800,
+    });
+    // A single-line arrow with a huge expression body, no internal newlines.
+    const hugeExpression = Array.from(
+      { length: 500 },
+      (_, i) => `value${i}`,
+    ).join(" + ");
+    const content = `export const compute = () => ${hugeExpression};`;
+
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "compute.ts" },
+    });
+
+    const combined = chunks.map((c) => c.content).join("");
+
+    // No chunk should carry the truncation marker.
+    const truncated = chunks.some((c) => c.content.includes("[truncated]"));
+    expect(truncated).toBe(false);
+
+    // The tail of the expression must survive somewhere.
+    expect(combined).toContain("value499");
+  });
 });

--- a/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
+++ b/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
@@ -203,4 +203,36 @@ function tiny2() { return 2; }
     // The tail of the expression must survive somewhere.
     expect(combined).toContain("value499");
   });
+
+  it("indexes export default function declarations", () => {
+    const content = `
+export default function compute(x: number): number {
+  return x * 2;
+}
+`;
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "default.ts" },
+    });
+
+    const combined = chunks.map((c) => c.content).join("\n");
+    expect(combined).toContain("function compute");
+    expect(combined).toContain("return x * 2");
+  });
+
+  it("indexes export default class declarations", () => {
+    const content = `
+export default class Service {
+  run() { return "ok"; }
+}
+`;
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "default.ts" },
+    });
+
+    const combined = chunks.map((c) => c.content).join("\n");
+    expect(combined).toContain("class Service");
+    expect(combined).toContain('return "ok"');
+  });
 });

--- a/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
+++ b/packages/context/src/chunking/__tests__/typescriptChunker.test.ts
@@ -1,0 +1,154 @@
+// packages/context/src/chunking/__tests__/typescriptChunker.test.ts
+
+import { createTypescriptChunker } from "../typescriptChunker.js";
+
+describe("createTypescriptChunker", () => {
+  const chunker = createTypescriptChunker();
+
+  it("emits one chunk per top-level declaration", () => {
+    const content = `
+      export function foo() { return 1; }
+
+      export class Bar {
+        baz() { return 2; }
+      }
+
+      export interface Quux {
+        x: number;
+      }
+    `;
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "test.ts" },
+    });
+
+    // Three top-level declarations → three chunks (no merging since none are tiny)
+    // BUT — small declarations may merge. Check the symbols, not the count.
+    const symbols = chunks.flatMap((c) => c.metadata?.symbols ?? []);
+    expect(symbols).toEqual(expect.arrayContaining(["foo", "Bar", "Quux"]));
+  });
+
+  it("attaches JSDoc to the symbol it documents", () => {
+    const content = `
+/**
+ * Authenticates a user.
+ */
+export function authenticate(user: string): boolean {
+  return user.length > 0;
+}
+    `;
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "auth.ts" },
+    });
+
+    const authChunk = chunks.find((c) =>
+      c.metadata?.symbols?.includes("authenticate"),
+    );
+    expect(authChunk).toBeDefined();
+    expect(authChunk?.content).toContain("Authenticates a user");
+  });
+
+  it("skips import declarations", () => {
+    const content = `
+import { foo } from "./foo.js";
+import { bar } from "./bar.js";
+
+export function baz() { return foo() + bar(); }
+    `;
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "baz.ts" },
+    });
+
+    // No chunk should be just the imports.
+    const importOnlyChunks = chunks.filter(
+      (c) =>
+        c.content.trim().startsWith("import") &&
+        !c.content.includes("function"),
+    );
+    expect(importOnlyChunks).toHaveLength(0);
+  });
+
+  it("marks exported declarations as exported", () => {
+    const content = `
+export function publicFn() {
+  // Pad this function with enough content to exceed the merge threshold.
+  const result = [];
+  for (let i = 0; i < 100; i++) {
+    result.push(i * 2);
+  }
+  return result.reduce((a, b) => a + b, 0);
+}
+
+function privateFn() {
+  // Same here - pad to keep this chunk separate from publicFn.
+  const items = ["a", "b", "c", "d", "e"];
+  return items.map((x) => x.toUpperCase()).join(",");
+}
+  `;
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "mixed.ts" },
+    });
+
+    const pub = chunks.find((c) => c.metadata?.symbols?.includes("publicFn"));
+    const priv = chunks.find((c) => c.metadata?.symbols?.includes("privateFn"));
+
+    expect(pub?.metadata?.exported).toBe(true);
+    expect(priv?.metadata?.exported).toBe(false);
+  });
+
+  it("records line numbers", () => {
+    const content = [
+      "// line 1",
+      "// line 2",
+      "export function lineThree() {",
+      "  return 'hi';",
+      "}",
+    ].join("\n");
+
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "lines.ts" },
+    });
+
+    const c = chunks.find((x) => x.metadata?.symbols?.includes("lineThree"));
+    expect(c?.metadata?.lineStart).toBe(3);
+    expect(c?.metadata?.lineEnd).toBeGreaterThanOrEqual(5);
+  });
+
+  it("falls back gracefully on syntactically broken input", () => {
+    const content = "this is not valid ;;; typescript {{{ at all";
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "broken.ts" },
+    });
+
+    // Should produce at least one chunk, not throw.
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  it("merges small declarations and reports exported=true if any merged symbol is exported", () => {
+    const content = `
+export function tiny1() { return 1; }
+function tiny2() { return 2; }
+  `;
+    const chunks = chunker.chunk({
+      content,
+      source: { kind: "file", path: "tiny.ts" },
+    });
+
+    // Both tiny functions merge into one chunk.
+    const merged = chunks.find(
+      (c) =>
+        c.metadata?.symbols?.includes("tiny1") &&
+        c.metadata?.symbols?.includes("tiny2"),
+    );
+    expect(merged).toBeDefined();
+
+    // At chunk level, "exported" means "at least one symbol in this chunk is exported"
+    // — not per-symbol granularity. Per-symbol export tracking is a future concern.
+    expect(merged?.metadata?.exported).toBe(true);
+  });
+});

--- a/packages/context/src/chunking/charChunker.ts
+++ b/packages/context/src/chunking/charChunker.ts
@@ -1,3 +1,4 @@
+// packages/context/src/chunking/charChunker.ts
 import type { Chunker } from "./types.js";
 import type { ContextChunk, ContextSource } from "@prsense/core";
 import { randomUUID } from "node:crypto";

--- a/packages/context/src/chunking/compositeChunker.ts
+++ b/packages/context/src/chunking/compositeChunker.ts
@@ -1,0 +1,37 @@
+// packages/context/src/chunking/compositeChunker.ts
+import path from "node:path";
+
+import type { Chunker } from "./types.js";
+
+import { createCharChunker, type CharChunkerOptions } from "./charChunker.js";
+
+import {
+  createTypescriptChunker,
+  type TypeScriptChunkerOptions,
+} from "./typescriptChunker.js";
+
+export type CompositeChunkerOptions = {
+  char: CharChunkerOptions;
+  typescript?: Partial<TypeScriptChunkerOptions>;
+};
+
+const TS_EXTENSIONS = new Set([".ts", ".tsx"]);
+
+export function createCompositeChunker(
+  options: CompositeChunkerOptions,
+): Chunker {
+  const charChunker = createCharChunker(options.char);
+
+  const tsChunker = createTypescriptChunker(options.typescript ?? {});
+
+  return {
+    chunk({ content, source }) {
+      const filePath = source.kind === "file" ? source.path : "";
+      const ext = path.extname(filePath).toLowerCase();
+      if (TS_EXTENSIONS.has(ext)) {
+        return tsChunker.chunk({ content, source });
+      }
+      return charChunker.chunk({ content, source });
+    },
+  };
+}

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -140,11 +140,13 @@ function extractRawChunks(
   // The splitting logic above should already keep chunks within bounds, but
   // if any code path produces an oversized chunk, truncate it here rather
   // than letting the embedding step reject the entire indexing run.
+  const TRUNCATION_MARKER = "\n// [truncated]";
   return chunks.map((c) => {
     if (c.content.length <= opts.hardMaxChars) return c;
+    const sliceLength = opts.hardMaxChars - TRUNCATION_MARKER.length;
     return {
       ...c,
-      content: c.content.slice(0, opts.hardMaxChars) + "\n// [truncated]",
+      content: c.content.slice(0, sliceLength) + TRUNCATION_MARKER,
     };
   });
 }
@@ -313,10 +315,10 @@ function splitTextAtLineBoundaries(
         kindLabel: `${kindLabel}-partial`,
         exported,
         lineStart: currentStartLine,
-        lineEnd: lineCursor,
+        lineEnd: lineCursor - 1,
       });
       current = "";
-      currentStartLine = lineCursor + 1;
+      currentStartLine = lineCursor;
     }
     current += (current.length > 0 ? "\n" : "") + line;
     lineCursor++;
@@ -329,7 +331,7 @@ function splitTextAtLineBoundaries(
       kindLabel: `${kindLabel}-partial`,
       exported,
       lineStart: currentStartLine,
-      lineEnd: lineCursor,
+      lineEnd: lineCursor - 1,
     });
   }
 
@@ -439,6 +441,7 @@ function isExported(stmt: Node): boolean {
   ) {
     return stmt.isExported();
   }
+  if (Node.isExportAssignment(stmt)) return true;
   return false;
 }
 

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -96,18 +96,14 @@ function extractRawChunks(
 
   for (const stmt of sourceFile.getStatements()) {
     const kind = stmt.getKind();
-
     if (SKIPPABLE_KINDS.has(kind)) continue;
     if (!CHUNKABLE_KINDS.has(kind)) continue;
 
     // include leading jsdoc / comments profusely
     const fullStart = stmt.getStart(/* include jsdoc comments */ true);
     const end = stmt.getEnd();
-
     const text = sourceFile.getFullText().slice(fullStart, end);
-
     const lineStart = sourceFile.getLineAndColumnAtPos(fullStart).line;
-
     const lineEnd = sourceFile.getLineAndColumnAtPos(end).line;
 
     const symbolName = getSymbolName(stmt);
@@ -140,7 +136,17 @@ function extractRawChunks(
     }
   }
 
-  return chunks;
+  // Belt-and-suspenders: enforce hardMaxChars on every emitted chunk.
+  // The splitting logic above should already keep chunks within bounds, but
+  // if any code path produces an oversized chunk, truncate it here rather
+  // than letting the embedding step reject the entire indexing run.
+  return chunks.map((c) => {
+    if (c.content.length <= opts.hardMaxChars) return c;
+    return {
+      ...c,
+      content: c.content.slice(0, opts.hardMaxChars) + "\n// [truncated]",
+    };
+  });
 }
 
 // splitting large declarations

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -144,9 +144,13 @@ function extractRawChunks(
   return chunks.map((c) => {
     if (c.content.length <= opts.hardMaxChars) return c;
     const sliceLength = opts.hardMaxChars - TRUNCATION_MARKER.length;
+    const truncated = c.content.slice(0, sliceLength) + TRUNCATION_MARKER;
+    // Recompute lineEnd from the truncated content.
+    const linesPreserved = truncated.split("\n").length;
     return {
       ...c,
-      content: c.content.slice(0, sliceLength) + TRUNCATION_MARKER,
+      content: truncated,
+      lineEnd: c.lineStart + linesPreserved - 1,
     };
   });
 }
@@ -304,27 +308,8 @@ function splitTextAtLineBoundaries(
   let lineCursor = startLine;
   let currentStartLine = startLine;
 
-  for (const line of lines) {
-    if (
-      current.length + line.length + 1 > opts.targetMaxChars &&
-      current.length > 0
-    ) {
-      chunks.push({
-        content: current,
-        symbolNames: symbolName ? [symbolName] : [],
-        kindLabel: `${kindLabel}-partial`,
-        exported,
-        lineStart: currentStartLine,
-        lineEnd: lineCursor - 1,
-      });
-      current = "";
-      currentStartLine = lineCursor;
-    }
-    current += (current.length > 0 ? "\n" : "") + line;
-    lineCursor++;
-  }
-
-  if (current.trim().length > 0) {
+  const flushCurrent = () => {
+    if (current.trim().length === 0) return;
     chunks.push({
       content: current,
       symbolNames: symbolName ? [symbolName] : [],
@@ -333,7 +318,47 @@ function splitTextAtLineBoundaries(
       lineStart: currentStartLine,
       lineEnd: lineCursor - 1,
     });
+    current = "";
+  };
+
+  for (const line of lines) {
+    // Handle an overlong single line: flush whatever we have, then split
+    // the line itself into segments under hardMaxChars. Each segment becomes
+    // its own chunk with the same line number (since they all originated
+    // from one source line).
+    if (line.length > opts.hardMaxChars) {
+      flushCurrent();
+      currentStartLine = lineCursor;
+
+      const segmentSize = opts.targetMaxChars;
+      for (let i = 0; i < line.length; i += segmentSize) {
+        const segment = line.slice(i, i + segmentSize);
+        chunks.push({
+          content: segment,
+          symbolNames: symbolName ? [symbolName] : [],
+          kindLabel: `${kindLabel}-partial`,
+          exported,
+          lineStart: lineCursor,
+          lineEnd: lineCursor,
+        });
+      }
+      lineCursor++;
+      currentStartLine = lineCursor;
+      continue;
+    }
+
+    if (
+      current.length + line.length + 1 > opts.targetMaxChars &&
+      current.length > 0
+    ) {
+      flushCurrent();
+      currentStartLine = lineCursor;
+    }
+    current += (current.length > 0 ? "\n" : "") + line;
+    lineCursor++;
   }
+
+  flushCurrent();
 
   return chunks;
 }

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -19,9 +19,9 @@ export type TypeScriptChunkerOptions = {
 
 const DEFAULT_OPTIONS: TypeScriptChunkerOptions = {
   targetMinChars: 200, // try to not emit chunks smaller than this
-  targetMaxChars: 2000, // try to not emit chunks larger than this
+  targetMaxChars: 1500, // try to not emit chunks larger than this
   hardMinChars: 100, // force-merge below this
-  hardMaxChars: 3000, // force-split above this
+  hardMaxChars: 2000, // force-split above this
 };
 
 // Node kinds we treat as chunkable top-level declarations
@@ -219,6 +219,27 @@ function subSplitLargeDeclaration(
 
   for (const bodyStmt of bodyStatements) {
     const stmtText = bodyStmt.getFullText();
+
+    if (stmtText.length > opts.hardMaxChars) {
+      // Flush whatever we've accumulated, then split this enormous statement
+      // at line boundaries.
+      flush();
+      const stmtStart = bodyStmt.getStart();
+      const lineStart = sourceFile.getLineAndColumnAtPos(stmtStart).line;
+      const subChunks = splitTextAtLineBoundaries(
+        stmtText,
+        opts,
+        symbolName,
+        kindLabel,
+        exported,
+        lineStart,
+      );
+      chunks.push(...subChunks);
+      currentStart = bodyStmt.getEnd();
+      currentEnd = currentStart;
+      continue;
+    }
+
     if (
       currentText.length + stmtText.length > opts.targetMaxChars &&
       currentText.length > 0

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -25,7 +25,7 @@ const CHUNKABLE_KINDS = new Set<SyntaxKind>([
   SyntaxKind.InterfaceDeclaration,
   SyntaxKind.TypeAliasDeclaration,
   SyntaxKind.EnumDeclaration,
-  SyntaxKind.VariableDeclaration,
+  SyntaxKind.VariableStatement,
   SyntaxKind.ExportAssignment,
   SyntaxKind.ExpressionStatement,
 ]);
@@ -214,7 +214,7 @@ function subSplitLargeDeclaration(
   for (const bodyStmt of bodyStatements) {
     const stmtText = bodyStmt.getFullText();
     if (
-      currentText.length + stmtText.length > opts.hardMaxChars &&
+      currentText.length + stmtText.length > opts.targetMaxChars &&
       currentText.length > 0
     ) {
       flush();
@@ -245,10 +245,10 @@ function findSplittableBody(stmt: Node): Node | undefined {
     for (const d of decls) {
       const init = d.getInitializer();
       if (
-        (init && Node.isArrowFunction(init)) ||
-        Node.isFunctionExpression(init)
+        init &&
+        (Node.isArrowFunction(init) || Node.isFunctionExpression(init))
       )
-        return init.getBody as Node;
+        return init.getBody() as Node;
     }
   }
   return undefined;
@@ -327,7 +327,7 @@ function mergeSmallSiblings(
     const shouldMerge =
       (buffer.content.length < opts.hardMinChars ||
         chunk.content.length < opts.hardMinChars ||
-        (buffer.content.length <= opts.targetMinChars &&
+        (buffer.content.length < opts.targetMinChars &&
           wouldMergeSize <= opts.targetMaxChars)) &&
       wouldMergeSize <= opts.hardMaxChars;
 
@@ -347,7 +347,7 @@ function mergeSmallSiblings(
     }
   }
 
-  if (buffer != null) merged.push(buffer);
+  if (buffer !== null) merged.push(buffer);
   return merged;
 }
 
@@ -361,7 +361,7 @@ function getSymbolName(stmt: Node): string | undefined {
   if (Node.isTypeAliasDeclaration(stmt)) return stmt.getName();
 
   if (Node.isEnumDeclaration(stmt)) return stmt.getName();
-  if (Node.isVariableDeclaration(stmt)) {
+  if (Node.isVariableStatement(stmt)) {
     const decls = stmt.getDeclarations();
     const first = decls[0];
     if (first) return first.getName();

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -82,3 +82,366 @@ export function createTypescriptChunker(
 }
 
 // Extraction
+function extractRawChunks(
+  sourceFile: SourceFile,
+  opts: TypeScriptChunkerOptions,
+): RawChunk[] {
+  const chunks: RawChunk[] = [];
+
+  for (const stmt of sourceFile.getStatements()) {
+    const kind = stmt.getKind();
+
+    if (SKIPPABLE_KINDS.has(kind)) continue;
+    if (!CHUNKABLE_KINDS.has(kind)) continue;
+
+    // include leading jsdoc / comments profusely
+    const fullStart = stmt.getStart(/* include jsdoc comments */ true);
+    const end = stmt.getEnd();
+
+    const text = sourceFile.getFullText().slice(fullStart, end);
+
+    const lineStart = sourceFile.getLineAndColumnAtPos(fullStart).line;
+
+    const lineEnd = sourceFile.getLineAndColumnAtPos(end).line;
+
+    const symbolName = getSymbolName(stmt);
+    const kindLabel = getKindLabel(stmt);
+    const exported = isExported(stmt);
+
+    const text_trimmed = text.trim();
+    if (text_trimmed.length === 0) continue;
+
+    if (text.length <= opts.hardMaxChars) {
+      chunks.push({
+        content: text,
+        symbolName,
+        kindLabel,
+        exported,
+        lineStart,
+        lineEnd,
+      });
+    } else {
+      // split large bodies at statement boundaries
+      const subChunks = subSplitLargeDeclaration(
+        stmt,
+        sourceFile,
+        opts,
+        symbolName,
+        kindLabel,
+        exported,
+      );
+      chunks.push(...subChunks);
+    }
+  }
+
+  return chunks;
+}
+
+// splitting large declarations
+function subSplitLargeDeclaration(
+  stmt: Node,
+  sourceFile: SourceFile,
+  opts: TypeScriptChunkerOptions,
+  symbolName: string | undefined,
+  kindLabel: string,
+  exported: boolean,
+): RawChunk[] {
+  // find the body block and split
+  // for larger nodes fall back to splitting the raw text at line boundaries near targetMaxChars
+
+  const body = findSplittableBody(stmt);
+
+  if (!body) {
+    return splitTextAtLineBoundaries(
+      sourceFile.getFullText().slice(stmt.getStart(true), stmt.getEnd()),
+      opts,
+      symbolName,
+      kindLabel,
+      exported,
+      sourceFile.getLineAndColumnAtPos(stmt.getStart(true)).line,
+    );
+  }
+
+  const bodyStatements = body.getStatements();
+  if (bodyStatements.length === 0) {
+    // empty body but huge declaration
+    return splitTextAtLineBoundaries(
+      sourceFile.getFullText().slice(stmt.getStart(true), stmt.getEnd()),
+      opts,
+      symbolName,
+      kindLabel,
+      exported,
+      sourceFile.getLineAndColumnAtPos(stmt.getStart(true)).line,
+    );
+  }
+
+  // build a "header" chunk (declaration signature + opening brace)
+  const declStart = stmt.getStart(true);
+  const bodyStart = body.getStart();
+  const headerText = sourceFile.getFullText().slice(declStart, bodyStart + 1);
+
+  const chunks: RawChunk[] = [];
+
+  chunks.push({
+    content: headerText + "\n // ...",
+    symbolName,
+    kindLabel: `${kindLabel}-header`,
+    exported,
+    lineStart: sourceFile.getLineAndColumnAtPos(declStart).line,
+    lineEnd: sourceFile.getLineAndColumnAtPos(bodyStart).line,
+  });
+
+  // Group body statements into chunks of ~targetMaxChars
+  let currentText = "";
+  let currentStart = bodyStatements[0]!.getStart();
+  let currentEnd = currentStart;
+
+  const flush = () => {
+    if (currentText.trim().length === 0) return;
+
+    chunks.push({
+      content: `// inside ${symbolName ?? kindLabel}\n${currentText}`,
+      symbolName,
+      kindLabel: `${kindLabel}-body`,
+      exported,
+      lineStart: sourceFile.getLineAndColumnAtPos(currentStart).line,
+      lineEnd: sourceFile.getLineAndColumnAtPos(currentEnd).line,
+    });
+
+    currentText = "";
+  };
+
+  for (const bodyStmt of bodyStatements) {
+    const stmtText = bodyStmt.getFullText();
+    if (
+      currentText.length + stmtText.length > opts.hardMaxChars &&
+      currentText.length > 0
+    ) {
+      flush();
+      currentStart = bodyStmt.getStart();
+    }
+    currentText += stmtText;
+    currentEnd = bodyStmt.getEnd();
+  }
+  flush();
+  return chunks;
+}
+
+function findSplittableBody(stmt: Node): Node | undefined {
+  // find the inner block of a function, method, or class
+  if (Node.isFunctionDeclaration(stmt) || Node.isFunctionExpression(stmt)) {
+    return stmt.getBody();
+  }
+
+  if (Node.isClassDeclaration(stmt)) {
+    // for classes we treat the class body as a list of members
+    // return the first block shaped descendant or undefined to fall back to text splitting
+    return undefined;
+  }
+
+  if (Node.isVariableStatement(stmt)) {
+    // look for arrow fn or fn expression initializer
+    const decls = stmt.getDeclarations();
+    for (const d of decls) {
+      const init = d.getInitializer();
+      if (
+        (init && Node.isArrowFunction(init)) ||
+        Node.isFunctionExpression(init)
+      )
+        return init.getBody as Node;
+    }
+  }
+  return undefined;
+}
+
+function splitTextAtLineBoundaries(
+  text: string,
+  opts: TypeScriptChunkerOptions,
+  symbolName: string | undefined,
+  kindLabel: string,
+  exported: boolean,
+  startLine: number,
+): RawChunk[] {
+  const lines = text.split("\n");
+  const chunks: RawChunk[] = [];
+
+  let current = "";
+  let lineCursor = startLine;
+  let currentStartLine = startLine;
+
+  for (const line of lines) {
+    if (
+      current.length + line.length + 1 > opts.targetMaxChars &&
+      current.length > 0
+    ) {
+      chunks.push({
+        content: current,
+        symbolName,
+        kindLabel: `${kindLabel}-partial`,
+        exported,
+        lineStart: currentStartLine,
+        lineEnd: lineCursor,
+      });
+      current = "";
+      currentStartLine = lineCursor + 1;
+    }
+    current += (current.length > 0 ? "\n" : "") + line;
+    lineCursor++;
+  }
+
+  if (current.trim().length > 0) {
+    chunks.push({
+      content: current,
+      symbolName,
+      kindLabel: `${kindLabel}-partial`,
+      exported,
+      lineStart: currentStartLine,
+      lineEnd: lineCursor,
+    });
+  }
+
+  return chunks;
+}
+
+// handle small siblings by merging
+function mergeSmallSiblings(
+  chunks: RawChunk[],
+  opts: TypeScriptChunkerOptions,
+): RawChunk[] {
+  if (chunks.length === 0) return chunks;
+
+  const merged: RawChunk[] = [];
+  let buffer: RawChunk | null = null;
+
+  for (const chunk of chunks) {
+    if (buffer === null) {
+      buffer = chunk;
+      continue;
+    }
+
+    const wouldMergeSize = buffer.content.length + chunk.content.length;
+
+    // merge if either is below hard min or if buffer is below target min
+    // and the merged size stays within target max
+    //
+    const shouldMerge =
+      (buffer.content.length < opts.hardMinChars ||
+        chunk.content.length < opts.hardMinChars ||
+        (buffer.content.length <= opts.targetMinChars &&
+          wouldMergeSize <= opts.targetMaxChars)) &&
+      wouldMergeSize <= opts.hardMaxChars;
+
+    if (shouldMerge) {
+      buffer = {
+        content: buffer.content + "\n\n" + chunk.content,
+        symbolName: buffer.symbolName ?? chunk.symbolName,
+        kindLabel:
+          buffer.kindLabel === chunk.kindLabel ? buffer.kindLabel : "mixed",
+        exported: buffer.exported || chunk.exported,
+        lineStart: buffer.lineStart,
+        lineEnd: chunk.lineEnd,
+      };
+    } else {
+      merged.push(buffer);
+      buffer = chunk;
+    }
+  }
+
+  if (buffer != null) merged.push(buffer);
+  return merged;
+}
+
+// symbol / kind extraction
+function getSymbolName(stmt: Node): string | undefined {
+  if (Node.isFunctionDeclaration(stmt)) return stmt.getName();
+  if (Node.isClassDeclaration(stmt)) return stmt.getName();
+
+  if (Node.isInterfaceDeclaration(stmt)) return stmt.getName();
+
+  if (Node.isTypeAliasDeclaration(stmt)) return stmt.getName();
+
+  if (Node.isEnumDeclaration(stmt)) return stmt.getName();
+  if (Node.isVariableDeclaration(stmt)) {
+    const decls = stmt.getDeclarations();
+    const first = decls[0];
+    if (first) return first.getName();
+  }
+  if (Node.isExportAssignment(stmt)) return "default";
+  return undefined;
+}
+
+function getKindLabel(stmt: Node): string {
+  const kind = stmt.getKind();
+
+  switch (kind) {
+    case SyntaxKind.FunctionDeclaration:
+      return "function";
+    case SyntaxKind.ClassDeclaration:
+      return "class";
+    case SyntaxKind.InterfaceDeclaration:
+      return "interface";
+    case SyntaxKind.TypeAliasDeclaration:
+      return "type";
+    case SyntaxKind.EnumDeclaration:
+      return "enum";
+    case SyntaxKind.VariableStatement:
+      return "variable";
+    case SyntaxKind.ExportAssignment:
+      return "default-export";
+    case SyntaxKind.ExpressionStatement:
+      return "expression";
+    default:
+      return "unknown";
+  }
+}
+
+function isExported(stmt: Node): boolean {
+  if (
+    Node.isFunctionDeclaration(stmt) ||
+    Node.isClassDeclaration(stmt) ||
+    Node.isInterfaceDeclaration(stmt) ||
+    Node.isTypeAliasDeclaration(stmt) ||
+    Node.isEnumDeclaration(stmt) ||
+    Node.isVariableStatement(stmt)
+  ) {
+    return stmt.isExported();
+  }
+  return false;
+}
+
+// output mapping
+function toContextChunk(raw: RawChunk, source: ContextSource): ContextChunk {
+  const metadata: ContextChunk["metadata"] = {
+    symbols: raw.symbolName ? [raw.symbolName] : [],
+    language: "typescript",
+    lineStart: raw.lineStart,
+    lineEnd: raw.lineEnd,
+    kind: "code",
+    // extra fields under the index signature
+    symbolKind: raw.kindLabel,
+    exported: raw.exported,
+  };
+
+  return {
+    id: randomUUID(),
+    source,
+    content: raw.content,
+    metadata,
+  };
+}
+
+function singleChunkFallback(
+  content: string,
+  source: ContextSource,
+): ContextChunk {
+  return {
+    id: randomUUID(),
+    source,
+    content,
+    metadata: {
+      symbols: [],
+      language: "typescript",
+      kind: "code",
+    },
+  };
+}

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -166,6 +166,14 @@ function subSplitLargeDeclaration(
 ): RawChunk[] {
   // class declarations split on member boundaries instead of statement boundaries - methods, properties, accessors, constructors
   if (Node.isClassDeclaration(stmt)) {
+    return subSplitClassDeclaration(
+      stmt,
+      sourceFile,
+      opts,
+      symbolName,
+      kindLabel,
+      exported,
+    );
   }
   // find the body block and split
 

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -108,22 +108,26 @@ function extractRawChunks(
 
   for (const stmt of sourceFile.getStatements()) {
     const kind = stmt.getKind();
-    if (SKIPPABLE_KINDS.has(kind)) continue;
-    if (!CHUNKABLE_KINDS.has(kind)) continue;
 
-    // include leading jsdoc / comments profusely
-    const fullStart = stmt.getStart(/* include jsdoc comments */ true);
+    // Imports/exports carry no retrieval value as standalone chunks.
+    if (SKIPPABLE_KINDS.has(kind)) continue;
+
+    const fullStart = stmt.getStart(true);
     const end = stmt.getEnd();
     const text = sourceFile.getFullText().slice(fullStart, end);
+    const text_trimmed = text.trim();
+    if (text_trimmed.length === 0) continue;
+
     const lineStart = sourceFile.getLineAndColumnAtPos(fullStart).line;
     const lineEnd = sourceFile.getLineAndColumnAtPos(end).line;
 
-    const symbolName = getSymbolName(stmt);
-    const kindLabel = getKindLabel(stmt);
-    const exported = isExported(stmt);
-
-    const text_trimmed = text.trim();
-    if (text_trimmed.length === 0) continue;
+    // Known declaration kinds get rich metadata (symbol name, exported, etc.).
+    // Everything else (top-level if/for/try/switch/bare blocks/throws) is
+    // emitted as a generic code chunk so its content is preserved in the index.
+    const isChunkableDeclaration = CHUNKABLE_KINDS.has(kind);
+    const symbolName = isChunkableDeclaration ? getSymbolName(stmt) : undefined;
+    const kindLabel = isChunkableDeclaration ? getKindLabel(stmt) : "statement";
+    const exported = isChunkableDeclaration ? isExported(stmt) : false;
 
     if (text.length <= opts.hardMaxChars) {
       chunks.push({
@@ -135,7 +139,6 @@ function extractRawChunks(
         lineEnd,
       });
     } else {
-      // split large bodies at statement boundaries
       const subChunks = subSplitLargeDeclaration(
         stmt,
         sourceFile,

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -55,6 +55,12 @@ export function createTypescriptChunker(
 ): Chunker {
   const opts = { ...DEFAULT_OPTIONS, ...options };
 
+  if (opts.targetMaxChars > opts.hardMaxChars)
+    throw new Error("targetMaxChars must be <= hardMaxChars");
+
+  if (opts.hardMinChars > opts.targetMinChars)
+    throw new Error("hardMinChars must be <= targetMinChars");
+
   return {
     chunk({ content, source }) {
       const filePath = source.kind === "file" ? source.path : "unknown.ts";

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -43,7 +43,7 @@ const SKIPPABLE_KINDS = new Set<SyntaxKind>([
 
 type RawChunk = {
   content: string;
-  symbolName: string | undefined;
+  symbolNames: string[];
   kindLabel: string;
   exported: boolean;
   lineStart: number;
@@ -120,7 +120,7 @@ function extractRawChunks(
     if (text.length <= opts.hardMaxChars) {
       chunks.push({
         content: text,
-        symbolName,
+        symbolNames: symbolName ? [symbolName] : [],
         kindLabel,
         exported,
         lineStart,
@@ -190,7 +190,7 @@ function subSplitLargeDeclaration(
 
   chunks.push({
     content: headerText + "\n // ...",
-    symbolName,
+    symbolNames: symbolName ? [symbolName] : [],
     kindLabel: `${kindLabel}-header`,
     exported,
     lineStart: sourceFile.getLineAndColumnAtPos(declStart).line,
@@ -207,7 +207,7 @@ function subSplitLargeDeclaration(
 
     chunks.push({
       content: `// inside ${symbolName ?? kindLabel}\n${currentText}`,
-      symbolName,
+      symbolNames: symbolName ? [symbolName] : [],
       kindLabel: `${kindLabel}-body`,
       exported,
       lineStart: sourceFile.getLineAndColumnAtPos(currentStart).line,
@@ -282,7 +282,7 @@ function splitTextAtLineBoundaries(
     ) {
       chunks.push({
         content: current,
-        symbolName,
+        symbolNames: symbolName ? [symbolName] : [],
         kindLabel: `${kindLabel}-partial`,
         exported,
         lineStart: currentStartLine,
@@ -298,7 +298,7 @@ function splitTextAtLineBoundaries(
   if (current.trim().length > 0) {
     chunks.push({
       content: current,
-      symbolName,
+      symbolNames: symbolName ? [symbolName] : [],
       kindLabel: `${kindLabel}-partial`,
       exported,
       lineStart: currentStartLine,
@@ -340,7 +340,7 @@ function mergeSmallSiblings(
     if (shouldMerge) {
       buffer = {
         content: buffer.content + "\n\n" + chunk.content,
-        symbolName: buffer.symbolName ?? chunk.symbolName,
+        symbolNames: [...buffer.symbolNames, ...chunk.symbolNames],
         kindLabel:
           buffer.kindLabel === chunk.kindLabel ? buffer.kindLabel : "mixed",
         exported: buffer.exported || chunk.exported,
@@ -418,7 +418,7 @@ function isExported(stmt: Node): boolean {
 // output mapping
 function toContextChunk(raw: RawChunk, source: ContextSource): ContextChunk {
   const metadata: ContextChunk["metadata"] = {
-    symbols: raw.symbolName ? [raw.symbolName] : [],
+    symbols: raw.symbolNames,
     language: "typescript",
     lineStart: raw.lineStart,
     lineEnd: raw.lineEnd,

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -88,6 +88,12 @@ export function createTypescriptChunker(
       const rawChunks = extractRawChunks(sourceFile, opts);
       const merged = mergeSmallSiblings(rawChunks, opts);
 
+      // if we produced no chunks from non -empty content
+      // parsing likely failed to find any chunkable structure(malformed file, unusual syntax, etc)
+      // fall back to single chunk
+      if (merged.length === 0 && content.trim().length > 0)
+        return [singleChunkFallback(content, source)];
+
       return merged.map((raw) => toContextChunk(raw, source));
     },
   };

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -361,7 +361,7 @@ function splitTextAtLineBoundaries(
       flushCurrent();
       currentStartLine = lineCursor;
 
-      const segmentSize = opts.targetMaxChars;
+      const segmentSize = Math.min(opts.targetMaxChars, opts.hardMaxChars);
       for (let i = 0; i < line.length; i += segmentSize) {
         const segment = line.slice(i, i + segmentSize);
         chunks.push({

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -1,5 +1,11 @@
 // packages/context/src/chunking/typescriptChunker.ts
-import { Project, Node, SyntaxKind, type SourceFile } from "ts-morph";
+import {
+  Project,
+  Node,
+  SyntaxKind,
+  type SourceFile,
+  type Block,
+} from "ts-morph";
 import type { Chunker } from "./types.js";
 import type { ContextChunk, ContextSource } from "@prsense/core";
 import { randomUUID } from "node:crypto";
@@ -227,30 +233,30 @@ function subSplitLargeDeclaration(
   return chunks;
 }
 
-function findSplittableBody(stmt: Node): Node | undefined {
-  // find the inner block of a function, method, or class
+function findSplittableBody(stmt: Node): Block | undefined {
   if (Node.isFunctionDeclaration(stmt) || Node.isFunctionExpression(stmt)) {
-    return stmt.getBody();
+    const body = stmt.getBody();
+    return body && Node.isBlock(body) ? body : undefined;
   }
 
   if (Node.isClassDeclaration(stmt)) {
-    // for classes we treat the class body as a list of members
-    // return the first block shaped descendant or undefined to fall back to text splitting
     return undefined;
   }
 
   if (Node.isVariableStatement(stmt)) {
-    // look for arrow fn or fn expression initializer
     const decls = stmt.getDeclarations();
     for (const d of decls) {
       const init = d.getInitializer();
       if (
         init &&
         (Node.isArrowFunction(init) || Node.isFunctionExpression(init))
-      )
-        return init.getBody() as Node;
+      ) {
+        const body = init.getBody();
+        return Node.isBlock(body) ? body : undefined;
+      }
     }
   }
+
   return undefined;
 }
 

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -164,8 +164,10 @@ function subSplitLargeDeclaration(
   kindLabel: string,
   exported: boolean,
 ): RawChunk[] {
+  // class declarations split on member boundaries instead of statement boundaries - methods, properties, accessors, constructors
+  if (Node.isClassDeclaration(stmt)) {
+  }
   // find the body block and split
-  // for larger nodes fall back to splitting the raw text at line boundaries near targetMaxChars
 
   const body = findSplittableBody(stmt);
 
@@ -278,6 +280,8 @@ function findSplittableBody(stmt: Node): Block | undefined {
 
   if (Node.isVariableStatement(stmt)) {
     const decls = stmt.getDeclarations();
+    let bestBody: Block | undefined = undefined;
+    let bestSize = 0;
     for (const d of decls) {
       const init = d.getInitializer();
       if (
@@ -285,9 +289,16 @@ function findSplittableBody(stmt: Node): Block | undefined {
         (Node.isArrowFunction(init) || Node.isFunctionExpression(init))
       ) {
         const body = init.getBody();
-        return Node.isBlock(body) ? body : undefined;
+        if (Node.isBlock(body)) {
+          const size = body.getEnd() - body.getStart();
+          if (size > bestSize) {
+            bestSize = size;
+            bestBody = body;
+          }
+        }
       }
     }
+    return bestBody;
   }
 
   return undefined;
@@ -505,4 +516,128 @@ function singleChunkFallback(
       kind: "code",
     },
   };
+}
+
+function subSplitClassDeclaration(
+  cls: Node,
+  sourceFile: SourceFile,
+  opts: TypeScriptChunkerOptions,
+  symbolName: string | undefined,
+  kindLabel: string,
+  exported: boolean,
+): RawChunk[] {
+  if (!Node.isClassDeclaration(cls)) {
+    //should be unreachable given the caller's type guard
+    return [];
+  }
+
+  const members = cls.getMembers();
+  if (members.length === 0) {
+    return splitTextAtLineBoundaries(
+      sourceFile.getFullText().slice(cls.getStart(true), cls.getEnd()),
+      opts,
+      symbolName,
+      kindLabel,
+      exported,
+      sourceFile.getLineAndColumnAtPos(cls.getStart(true)).line,
+    );
+  }
+
+  const chunks: RawChunk[] = [];
+
+  // emit a header chunk = class declaration line + opening brace
+  // members follow as separate chunks
+  const declStart = cls.getStart(true);
+  const firstMemberStart = members[0]!.getStart();
+
+  const headerText = sourceFile
+    .getFullText()
+    .slice(declStart, firstMemberStart);
+
+  chunks.push({
+    content: headerText.trimEnd() + "\n // ...",
+    symbolNames: symbolName ? [symbolName] : [],
+    kindLabel: `${kindLabel}-header`,
+    exported,
+    lineStart: sourceFile.getLineAndColumnAtPos(declStart).line,
+    lineEnd: sourceFile.getLineAndColumnAtPos(firstMemberStart).line - 1,
+  });
+
+  // group members into chunks <= targetMaxChars.
+  // Each member that's itself
+  // larger than hardMaxChars falls through to text-line splitting
+  let currentText = "";
+  let currentStart = members[0]!.getStart();
+  let currentEnd = currentStart;
+  let currentMemberNames: string[] = [];
+
+  const flush = () => {
+    if (currentText.trim().length === 0) return;
+
+    chunks.push({
+      content: `// inside class ${symbolName ?? kindLabel}\n${currentText}`,
+      symbolNames: [...(symbolName ? [symbolName] : []), ...currentMemberNames],
+      kindLabel: `${kindLabel}-members`,
+      exported,
+      lineStart: sourceFile.getLineAndColumnAtPos(currentStart).line,
+      lineEnd: sourceFile.getLineAndColumnAtPos(currentEnd).line,
+    });
+    currentText = "";
+    currentMemberNames = [];
+  };
+
+  for (const member of members) {
+    const memberText = member.getFullText();
+    const memberName = getMemberName(member);
+
+    if (memberText.length > opts.hardMaxChars) {
+      flush();
+      currentStart = member.getEnd();
+      currentEnd = currentStart;
+
+      // fall through to line based splitting for this oversized member
+      const memberStart = sourceFile.getLineAndColumnAtPos(
+        member.getStart(),
+      ).line;
+      chunks.push(
+        ...splitTextAtLineBoundaries(
+          memberText,
+          opts,
+          memberName ?? symbolName,
+          `${kindLabel}-member`,
+          exported,
+          memberStart,
+        ),
+      );
+      continue;
+    }
+
+    if (
+      currentText.length + memberText.length > opts.targetMaxChars &&
+      currentText.length > 0
+    ) {
+      flush();
+      currentStart = member.getStart();
+    }
+    currentText += memberText;
+    currentEnd = member.getEnd();
+    if (memberName) currentMemberNames.push(memberName);
+  }
+
+  flush();
+  return chunks;
+}
+
+function getMemberName(member: Node): string | undefined {
+  if (
+    Node.isMethodDeclaration(member) ||
+    Node.isPropertyDeclaration(member) ||
+    Node.isGetAccessorDeclaration(member) ||
+    Node.isSetAccessorDeclaration(member)
+  )
+    return member.getName();
+
+  if (Node.isConstructorDeclaration(member)) return "constructor";
+
+  return undefined;
 }

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -255,7 +255,9 @@ function subSplitLargeDeclaration(
   };
 
   for (const bodyStmt of bodyStatements) {
-    const stmtText = bodyStmt.getFullText();
+    const stmtStart = bodyStmt.getStart(true);
+    const stmtEnd = bodyStmt.getEnd();
+    const stmtText = sourceFile.getFullText().slice(stmtStart, stmtEnd);
 
     if (stmtText.length > opts.hardMaxChars) {
       // Flush whatever we've accumulated, then split this enormous statement
@@ -610,7 +612,9 @@ function subSplitClassDeclaration(
   };
 
   for (const member of members) {
-    const memberText = member.getFullText();
+    const memberStart = member.getStart(true);
+    const memberEnd = member.getEnd();
+    const memberText = sourceFile.getFullText().slice(memberStart, memberEnd);
     const memberName = getMemberName(member);
 
     if (memberText.length > opts.hardMaxChars) {

--- a/packages/context/src/chunking/typescriptChunker.ts
+++ b/packages/context/src/chunking/typescriptChunker.ts
@@ -1,0 +1,84 @@
+// packages/context/src/chunking/typescriptChunker.ts
+import { Project, Node, SyntaxKind, type SourceFile } from "ts-morph";
+import type { Chunker } from "./types.js";
+import type { ContextChunk, ContextSource } from "@prsense/core";
+import { randomUUID } from "node:crypto";
+
+export type TypeScriptChunkerOptions = {
+  targetMinChars: number;
+  targetMaxChars: number;
+  hardMinChars: number;
+  hardMaxChars: number;
+};
+
+const DEFAULT_OPTIONS: TypeScriptChunkerOptions = {
+  targetMinChars: 200, // try to not emit chunks smaller than this
+  targetMaxChars: 2000, // try to not emit chunks larger than this
+  hardMinChars: 100, // force-merge below this
+  hardMaxChars: 3000, // force-split above this
+};
+
+// Node kinds we treat as chunkable top-level declarations
+const CHUNKABLE_KINDS = new Set<SyntaxKind>([
+  SyntaxKind.FunctionDeclaration,
+  SyntaxKind.ClassDeclaration,
+  SyntaxKind.InterfaceDeclaration,
+  SyntaxKind.TypeAliasDeclaration,
+  SyntaxKind.EnumDeclaration,
+  SyntaxKind.VariableDeclaration,
+  SyntaxKind.ExportAssignment,
+  SyntaxKind.ExpressionStatement,
+]);
+
+const SKIPPABLE_KINDS = new Set<SyntaxKind>([
+  SyntaxKind.ImportDeclaration,
+  SyntaxKind.ExportDeclaration,
+]);
+
+type RawChunk = {
+  content: string;
+  symbolName: string | undefined;
+  kindLabel: string;
+  exported: boolean;
+  lineStart: number;
+  lineEnd: number;
+};
+
+export function createTypescriptChunker(
+  options: Partial<TypeScriptChunkerOptions> = {},
+): Chunker {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  return {
+    chunk({ content, source }) {
+      const filePath = source.kind === "file" ? source.path : "unknown.ts";
+
+      let project: Project;
+      let sourceFile: SourceFile;
+
+      try {
+        project = new Project({
+          useInMemoryFileSystem: true,
+          compilerOptions: {
+            allowJs: true,
+            jsx: 4,
+          },
+        });
+        sourceFile = project.createSourceFile(filePath, content, {
+          overwrite: true,
+        });
+      } catch {
+        // if parsing fails fall back to a single chunk
+        // containing the whole file
+        return [singleChunkFallback(content, source)];
+      }
+
+      const rawChunks = extractRawChunks(sourceFile, opts);
+      const merged = mergeSmallSiblings(rawChunks, opts);
+
+      return merged.map((raw) => toContextChunk(raw, source));
+    },
+  };
+}
+
+// Extraction

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -3,6 +3,7 @@
 export * from "./chunking/types.js";
 export * from "./chunking/simpleChunker.js";
 export * from "./chunking/charChunker.js";
+export * from "./chunking/typescriptChunker.js";
 
 export * from "./repository/index.js";
 export * from "./index/index.js";

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -12,5 +12,6 @@ export * from "./utils/detectLanguage.js";
 export * from "./diff/LocalGitDiffProvider.js";
 export * from "./diff/GitHubPrDiffProvider.js";
 export * from "./diff/GitLabMrDiffProvider.js";
+export * from "./chunking/compositeChunker.js";
 
 export { ensureDatabaseSchema } from "./migrations/ensureDatabaseSchema.js";

--- a/packages/context/src/index/detectKind.ts
+++ b/packages/context/src/index/detectKind.ts
@@ -1,3 +1,4 @@
+// packages/context/src/index/detectKind.ts
 export type FileKind = "code" | "test" | "doc" | "config";
 
 export function detectKind(filePath: string): FileKind {

--- a/packages/context/src/utils/detectLanguage.ts
+++ b/packages/context/src/utils/detectLanguage.ts
@@ -1,3 +1,4 @@
+// packages/context/src/utils/detectLanguage.ts
 import path from "node:path";
 
 const extensionMap: Record<string, string> = {

--- a/packages/workflows/src/index/__tests__/db.ts
+++ b/packages/workflows/src/index/__tests__/db.ts
@@ -1,3 +1,4 @@
+// packages/workflows/src/index/__tests__/db.ts
 import { Client } from "pg";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -16,11 +17,8 @@ export async function initTestDb() {
 
   // Load your migration SQL
   const sql = await fs.readFile(
-    path.resolve(
-      __dirname,
-      "../../../../context/src/migrations/0001_init.sql"
-    ),
-    "utf8"
+    path.resolve(__dirname, "../../../../context/src/migrations/0001_init.sql"),
+    "utf8",
   );
 
   await client.query(sql);
@@ -37,3 +35,4 @@ export async function resetTestDb() {
 
   await client.end();
 }
+

--- a/packages/workflows/src/index/__tests__/incremental.test.ts
+++ b/packages/workflows/src/index/__tests__/incremental.test.ts
@@ -722,7 +722,7 @@ describe("Incremental indexing (real DB)", () => {
     await client.end();
   });
 
-  it("detects change even if file reverts to previous content", async () => {
+  it("treats reverted content across commits as noop(snapshot-based diff)", async () => {
     const eventBus = new TestEventBus();
 
     await writeFile(repo, "a.txt", "1");

--- a/packages/workflows/src/index/__tests__/incremental.test.ts
+++ b/packages/workflows/src/index/__tests__/incremental.test.ts
@@ -3,6 +3,12 @@ import path from "node:path";
 import fs from "node:fs/promises";
 import { CoreEvents } from "@prsense/core";
 
+// These tests use .txt fixtures intentionally. Incremental indexing behavior
+// (change detection, chunk insert/delete, rename handling) is orthogonal to
+// chunker selection. .txt routes through the char chunker, isolating the
+// incremental logic under test. TypeScript-specific AST chunking through the
+// index workflow is covered separately in incrementalAstChunking.test.ts.
+
 import { runIndexWorkflow } from "../indexWorkflow.js";
 import {
   createTestRepo,

--- a/packages/workflows/src/index/__tests__/incremental.test.ts
+++ b/packages/workflows/src/index/__tests__/incremental.test.ts
@@ -31,7 +31,7 @@ describe("Incremental indexing (real DB)", () => {
 
   beforeEach(async () => {
     await resetTestDb();
-    repo = await createTestRepo()
+    repo = await createTestRepo();
   });
 
   afterEach(async () => {
@@ -40,11 +40,11 @@ describe("Incremental indexing (real DB)", () => {
     }
   });
 
-  it("re-indexes only changed file", async () => {
+  it.only("re-indexes only changed file", async () => {
     const eventBus = new TestEventBus();
 
     // ---- initial commit ----
-    await writeFile(repo, "a.ts", "const a = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -57,7 +57,7 @@ describe("Incremental indexing (real DB)", () => {
     });
 
     // ---- update file ----
-    await writeFile(repo, "a.ts", "const a = 2;");
+    await writeFile(repo, "a.txt", "const a = 2;");
     commitAll(repo, "update");
 
     await runIndexWorkflow({
@@ -73,7 +73,7 @@ describe("Incremental indexing (real DB)", () => {
     await client.connect();
 
     const res = await client.query(
-      `SELECT content FROM rag_chunks WHERE path = 'a.ts'`
+      `SELECT content FROM rag_chunks WHERE path = 'a.txt'`,
     );
 
     const combined = res.rows.map((r) => r.content).join("\n");
@@ -84,12 +84,10 @@ describe("Incremental indexing (real DB)", () => {
     await client.end();
   });
 
-
-
   it("removes chunks for deleted file", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "const a = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -101,7 +99,7 @@ describe("Incremental indexing (real DB)", () => {
       version: "test",
     });
 
-    await fs.unlink(path.join(repo, "a.ts"));
+    await fs.unlink(path.join(repo, "a.txt"));
     commitAll(repo, "delete");
 
     await runIndexWorkflow({
@@ -116,7 +114,7 @@ describe("Incremental indexing (real DB)", () => {
     await client.connect();
 
     const res = await client.query(
-      `SELECT * FROM rag_chunks WHERE path = 'a.ts'`
+      `SELECT * FROM rag_chunks WHERE path = 'a.txt'`,
     );
 
     expect(res.rows.length).toBe(0);
@@ -128,7 +126,7 @@ describe("Incremental indexing (real DB)", () => {
     const eventBus = new TestEventBus();
 
     // ---- initial commit ----
-    await writeFile(repo, "a.ts", "const a = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -141,7 +139,7 @@ describe("Incremental indexing (real DB)", () => {
     });
 
     // ---- add new file ----
-    await writeFile(repo, "b.ts", "const b = 42;");
+    await writeFile(repo, "b.txt", "const b = 42;");
     commitAll(repo, "add b");
 
     await runIndexWorkflow({
@@ -157,7 +155,7 @@ describe("Incremental indexing (real DB)", () => {
     await client.connect();
 
     const res = await client.query(
-      `SELECT content FROM rag_chunks WHERE path = 'b.ts'`
+      `SELECT content FROM rag_chunks WHERE path = 'b.txt'`,
     );
 
     const combined = res.rows.map((r) => r.content).join("\n");
@@ -172,7 +170,7 @@ describe("Incremental indexing (real DB)", () => {
     const eventBus = new TestEventBus();
 
     // ---- initial commit ----
-    await writeFile(repo, "a.ts", "const a = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -202,7 +200,7 @@ describe("Incremental indexing (real DB)", () => {
   it("handles file rename correctly", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "const a = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -214,11 +212,8 @@ describe("Incremental indexing (real DB)", () => {
       version: "test",
     });
 
-    // rename a.ts → b.ts
-    await fs.rename(
-      path.join(repo, "a.ts"),
-      path.join(repo, "b.ts")
-    );
+    // rename a.txt → b.txt
+    await fs.rename(path.join(repo, "a.txt"), path.join(repo, "b.txt"));
     commitAll(repo, "rename");
 
     await runIndexWorkflow({
@@ -233,10 +228,10 @@ describe("Incremental indexing (real DB)", () => {
     await client.connect();
 
     const oldRes = await client.query(
-      `SELECT * FROM rag_chunks WHERE path = 'a.ts'`
+      `SELECT * FROM rag_chunks WHERE path = 'a.txt'`,
     );
     const newRes = await client.query(
-      `SELECT * FROM rag_chunks WHERE path = 'b.ts'`
+      `SELECT * FROM rag_chunks WHERE path = 'b.txt'`,
     );
 
     expect(oldRes.rows.length).toBe(0);
@@ -248,8 +243,8 @@ describe("Incremental indexing (real DB)", () => {
   it("handles modify and delete in same commit", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "const a = 1;");
-    await writeFile(repo, "b.ts", "const b = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
+    await writeFile(repo, "b.txt", "const b = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -261,9 +256,9 @@ describe("Incremental indexing (real DB)", () => {
       version: "test",
     });
 
-    // modify a.ts and delete b.ts
-    await writeFile(repo, "a.ts", "const a = 2;");
-    await fs.unlink(path.join(repo, "b.ts"));
+    // modify a.txt and delete b.txt
+    await writeFile(repo, "a.txt", "const a = 2;");
+    await fs.unlink(path.join(repo, "b.txt"));
     commitAll(repo, "mixed");
 
     await runIndexWorkflow({
@@ -278,13 +273,13 @@ describe("Incremental indexing (real DB)", () => {
     await client.connect();
 
     const aRes = await client.query(
-      `SELECT content FROM rag_chunks WHERE path = 'a.ts'`
+      `SELECT content FROM rag_chunks WHERE path = 'a.txt'`,
     );
     const bRes = await client.query(
-      `SELECT * FROM rag_chunks WHERE path = 'b.ts'`
+      `SELECT * FROM rag_chunks WHERE path = 'b.txt'`,
     );
 
-    const combined = aRes.rows.map(r => r.content).join("\n");
+    const combined = aRes.rows.map((r) => r.content).join("\n");
 
     expect(combined).toContain("2");
     expect(bRes.rows.length).toBe(0);
@@ -294,13 +289,13 @@ describe("Incremental indexing (real DB)", () => {
   it("handles multiple commits before indexing", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "c1");
 
-    await writeFile(repo, "a.ts", "2");
+    await writeFile(repo, "a.txt", "2");
     commitAll(repo, "c2");
 
-    await writeFile(repo, "a.ts", "3");
+    await writeFile(repo, "a.txt", "3");
     commitAll(repo, "c3");
 
     await runIndexWorkflow({
@@ -316,10 +311,10 @@ describe("Incremental indexing (real DB)", () => {
     await client.connect();
 
     const res = await client.query(
-      `SELECT content FROM rag_chunks WHERE path = 'a.ts'`
+      `SELECT content FROM rag_chunks WHERE path = 'a.txt'`,
     );
 
-    const combined = res.rows.map(r => r.content).join("\n");
+    const combined = res.rows.map((r) => r.content).join("\n");
 
     expect(combined).toContain("3");
 
@@ -328,24 +323,37 @@ describe("Incremental indexing (real DB)", () => {
   it("re-indexes multiple modified files", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
-    await writeFile(repo, "b.ts", "1");
+    await writeFile(repo, "a.txt", "1");
+    await writeFile(repo, "b.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await writeFile(repo, "a.ts", "2");
-    await writeFile(repo, "b.ts", "2");
+    await writeFile(repo, "a.txt", "2");
+    await writeFile(repo, "b.txt", "2");
     commitAll(repo, "update both");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
 
     const res = await client.query(`SELECT path, content FROM rag_chunks`);
 
-    const combined = res.rows.map(r => r.content).join("\n");
+    const combined = res.rows.map((r) => r.content).join("\n");
 
     expect(combined).toContain("2");
 
@@ -355,10 +363,17 @@ describe("Incremental indexing (real DB)", () => {
   it("handles empty commit gracefully", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
     commitAll(repo, "empty commit", { allowEmpty: true });
 
@@ -370,7 +385,7 @@ describe("Incremental indexing (real DB)", () => {
       version: "test",
     });
     const planEvents = eventBus.events.filter(
-      e => e.event === CoreEvents.WorkflowIndexPlanComputed
+      (e) => e.event === CoreEvents.WorkflowIndexPlanComputed,
     );
 
     expect(planEvents.at(-1)?.fields?.type).toBe("noop");
@@ -381,24 +396,39 @@ describe("Incremental indexing (real DB)", () => {
   it("handles delete and re-add of same file", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await fs.unlink(path.join(repo, "a.ts"));
+    await fs.unlink(path.join(repo, "a.txt"));
     commitAll(repo, "delete");
 
-    await writeFile(repo, "a.ts", "2");
+    await writeFile(repo, "a.txt", "2");
     commitAll(repo, "re-add");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
 
-    const res = await client.query(`SELECT content FROM rag_chunks WHERE path = 'a.ts'`);
-    const combined = res.rows.map(r => r.content).join("\n");
+    const res = await client.query(
+      `SELECT content FROM rag_chunks WHERE path = 'a.txt'`,
+    );
+    const combined = res.rows.map((r) => r.content).join("\n");
 
     expect(combined).toContain("2");
 
@@ -408,12 +438,19 @@ describe("Incremental indexing (real DB)", () => {
   it("force rebuild ignores incremental diff", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await writeFile(repo, "a.ts", "2");
+    await writeFile(repo, "a.txt", "2");
     commitAll(repo, "update");
 
     await runIndexWorkflow({
@@ -429,7 +466,7 @@ describe("Incremental indexing (real DB)", () => {
     await client.connect();
 
     const res = await client.query(`SELECT content FROM rag_chunks`);
-    const combined = res.rows.map(r => r.content).join("\n");
+    const combined = res.rows.map((r) => r.content).join("\n");
 
     expect(combined).toContain("2");
 
@@ -439,17 +476,32 @@ describe("Incremental indexing (real DB)", () => {
   it("does not duplicate chunks for unchanged files", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
 
-    const res = await client.query(`SELECT COUNT(*) FROM rag_chunks WHERE path = 'a.ts'`);
+    const res = await client.query(
+      `SELECT COUNT(*) FROM rag_chunks WHERE path = 'a.txt'`,
+    );
 
     expect(Number(res.rows[0].count)).toBeGreaterThan(0);
 
@@ -459,17 +511,30 @@ describe("Incremental indexing (real DB)", () => {
   it("handles multiple file deletions", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
-    await writeFile(repo, "b.ts", "1");
+    await writeFile(repo, "a.txt", "1");
+    await writeFile(repo, "b.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await fs.unlink(path.join(repo, "a.ts"));
-    await fs.unlink(path.join(repo, "b.ts"));
+    await fs.unlink(path.join(repo, "a.txt"));
+    await fs.unlink(path.join(repo, "b.txt"));
     commitAll(repo, "delete both");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
@@ -483,68 +548,99 @@ describe("Incremental indexing (real DB)", () => {
   it("handles rename + modify", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await fs.rename(path.join(repo, "a.ts"), path.join(repo, "b.ts"));
-    await writeFile(repo, "b.ts", "2");
+    await fs.rename(path.join(repo, "a.txt"), path.join(repo, "b.txt"));
+    await writeFile(repo, "b.txt", "2");
     commitAll(repo, "rename+modify");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
 
-    const res = await client.query(`SELECT content FROM rag_chunks WHERE path = 'b.ts'`);
+    const res = await client.query(
+      `SELECT content FROM rag_chunks WHERE path = 'b.txt'`,
+    );
 
-    expect(res.rows.map(r => r.content).join("\n")).toContain("2");
+    expect(res.rows.map((r) => r.content).join("\n")).toContain("2");
 
     await client.end();
   });
-
 
   it("handles large file chunking", async () => {
     const eventBus = new TestEventBus();
 
     const large = "x".repeat(2000);
-    await writeFile(repo, "a.ts", large);
+    await writeFile(repo, "a.txt", large);
     commitAll(repo, "large");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
 
-    const res = await client.query(`SELECT COUNT(*) FROM rag_chunks WHERE path = 'a.ts'`);
+    const res = await client.query(
+      `SELECT COUNT(*) FROM rag_chunks WHERE path = 'a.txt'`,
+    );
 
     expect(Number(res.rows[0].count)).toBeGreaterThan(1);
 
     await client.end();
   });
 
-
   it("handles diff across multiple commits", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "c1");
 
-    await writeFile(repo, "a.ts", "2");
+    await writeFile(repo, "a.txt", "2");
     commitAll(repo, "c2");
 
-    await writeFile(repo, "a.ts", "3");
+    await writeFile(repo, "a.txt", "3");
     commitAll(repo, "c3");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
 
-    const res = await client.query(`SELECT content FROM rag_chunks WHERE path = 'a.ts'`);
+    const res = await client.query(
+      `SELECT content FROM rag_chunks WHERE path = 'a.txt'`,
+    );
 
-    expect(res.rows.map(r => r.content).join("\n")).toContain("3");
+    expect(res.rows.map((r) => r.content).join("\n")).toContain("3");
 
     await client.end();
   });
@@ -552,50 +648,76 @@ describe("Incremental indexing (real DB)", () => {
   it("treats rename as delete + add (snapshot semantics)", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await fs.rename(path.join(repo, "a.ts"), path.join(repo, "b.ts"));
+    await fs.rename(path.join(repo, "a.txt"), path.join(repo, "b.txt"));
     commitAll(repo, "rename");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const deleteEvents = eventBus.events
-      .filter(e => e.event === CoreEvents.WorkflowIndexFilesDeleted)
+      .filter((e) => e.event === CoreEvents.WorkflowIndexFilesDeleted)
       .at(-1);
 
     const changeEvents = eventBus.events
-      .filter(e => e.event === CoreEvents.WorkflowIndexFilesChanged)
+      .filter((e) => e.event === CoreEvents.WorkflowIndexFilesChanged)
       .at(-1);
 
-    expect(deleteEvents?.fields?.deletedFiles).toContain("a.ts");
-    expect(changeEvents?.fields?.changedFiles).toContain("b.ts");
+    expect(deleteEvents?.fields?.deletedFiles).toContain("a.txt");
+    expect(changeEvents?.fields?.changedFiles).toContain("b.txt");
   });
 
   it("indexes same content under different paths independently", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "same");
+    await writeFile(repo, "a.txt", "same");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await writeFile(repo, "b.ts", "same");
+    await writeFile(repo, "b.txt", "same");
     commitAll(repo, "copy");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const client = new Client(DB_CONFIG);
     await client.connect();
 
     const res = await client.query(`SELECT path FROM rag_chunks`);
 
-    const paths = res.rows.map(r => r.path);
+    const paths = res.rows.map((r) => r.path);
 
-    expect(paths).toContain("a.ts");
-    expect(paths).toContain("b.ts");
+    expect(paths).toContain("a.txt");
+    expect(paths).toContain("b.txt");
 
     await client.end();
   });
@@ -603,21 +725,34 @@ describe("Incremental indexing (real DB)", () => {
   it("detects change even if file reverts to previous content", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "c1");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await writeFile(repo, "a.ts", "2");
+    await writeFile(repo, "a.txt", "2");
     commitAll(repo, "c2");
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "c3");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const planEvents = eventBus.events.filter(
-      e => e.event === CoreEvents.WorkflowIndexPlanComputed
+      (e) => e.event === CoreEvents.WorkflowIndexPlanComputed,
     );
 
     expect(planEvents.at(-1)?.fields?.type).toBe("noop");
@@ -626,19 +761,32 @@ describe("Incremental indexing (real DB)", () => {
   it("skips chunk building when only deletions occur", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
     const before = eventBus.events.length;
-    await fs.unlink(path.join(repo, "a.ts"));
+    await fs.unlink(path.join(repo, "a.txt"));
     commitAll(repo, "delete");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
     const afterEvents = eventBus.events.slice(before);
 
     const chunkEvents = afterEvents.filter(
-      e => e.event === CoreEvents.ContextChunksBuilt
+      (e) => e.event === CoreEvents.ContextChunksBuilt,
     );
 
     expect(chunkEvents.length).toBe(0);
@@ -647,10 +795,17 @@ describe("Incremental indexing (real DB)", () => {
   it("produces identical snapshots for identical commits", async () => {
     const eventBus = new TestEventBus();
 
-    await writeFile(repo, "a.ts", "1");
+    await writeFile(repo, "a.txt", "1");
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
     const result = await runIndexWorkflow({
       target: repo,
@@ -667,30 +822,43 @@ describe("Incremental indexing (real DB)", () => {
     const eventBus = new TestEventBus();
 
     for (let i = 0; i < 20; i++) {
-      await writeFile(repo, `f${i}.ts`, `${i}`);
+      await writeFile(repo, `f${i}.txt`, `${i}`);
     }
     commitAll(repo, "init");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), force: true, eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
 
-    await writeFile(repo, "f10.ts", "changed");
+    await writeFile(repo, "f10.txt", "changed");
     commitAll(repo, "modify one");
 
-    await runIndexWorkflow({ target: repo, config: testConfig(), credentials: testCredentials(), eventBus, version: "test" });
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
 
     const changeEvents = eventBus.events.filter(
-      e => e.event === CoreEvents.WorkflowIndexFilesChanged
+      (e) => e.event === CoreEvents.WorkflowIndexFilesChanged,
     );
 
     const last = changeEvents.at(-1);
 
-    expect(last?.fields?.changedFiles).toEqual(["f10.ts"]);
+    expect(last?.fields?.changedFiles).toEqual(["f10.txt"]);
   });
   it("handles delete-only commit (removes chunks and updates metadata)", async () => {
     const eventBus = new TestEventBus();
 
     // initial commit
-    await writeFile(repo, "a.ts", "const a = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -703,7 +871,7 @@ describe("Incremental indexing (real DB)", () => {
     });
 
     // delete file
-    await fs.unlink(path.join(repo, "a.ts"));
+    await fs.unlink(path.join(repo, "a.txt"));
     commitAll(repo, "delete");
 
     await runIndexWorkflow({
@@ -719,7 +887,7 @@ describe("Incremental indexing (real DB)", () => {
 
     // chunks should be gone
     const res = await client.query(
-      `SELECT * FROM rag_chunks WHERE path = 'a.ts'`
+      `SELECT * FROM rag_chunks WHERE path = 'a.txt'`,
     );
 
     expect(res.rows.length).toBe(0);
@@ -728,7 +896,7 @@ describe("Incremental indexing (real DB)", () => {
 
     // verify delete-only plan emitted
     const planEvent = eventBus.events
-      .filter(e => e.event === CoreEvents.WorkflowIndexPlanComputed)
+      .filter((e) => e.event === CoreEvents.WorkflowIndexPlanComputed)
       .at(-1);
 
     expect(planEvent?.fields?.type).toBe("delete-only");
@@ -738,7 +906,7 @@ describe("Incremental indexing (real DB)", () => {
     const eventBus = new TestEventBus();
 
     // initial commit
-    await writeFile(repo, "a.ts", "const a = 1;");
+    await writeFile(repo, "a.txt", "const a = 1;");
     commitAll(repo, "init");
 
     await runIndexWorkflow({
@@ -751,12 +919,15 @@ describe("Incremental indexing (real DB)", () => {
     });
 
     // capture metadata BEFORE
-    const metadataRepo = new PostgresIndexMetadataRepository(DB_CONFIG.connectionString ?? "postgres://prsense:prsense@localhost:10001/prsense_test");
+    const metadataRepo = new PostgresIndexMetadataRepository(
+      DB_CONFIG.connectionString ??
+        "postgres://prsense:prsense@localhost:10001/prsense_test",
+    );
 
     const before = await metadataRepo.load("local", path.basename(repo));
 
     // delete file
-    await fs.unlink(path.join(repo, "a.ts"));
+    await fs.unlink(path.join(repo, "a.txt"));
     commitAll(repo, "delete");
 
     await runIndexWorkflow({
@@ -773,7 +944,7 @@ describe("Incremental indexing (real DB)", () => {
 
     // chunks should STILL exist
     const res = await client.query(
-      `SELECT * FROM rag_chunks WHERE path = 'a.ts'`
+      `SELECT * FROM rag_chunks WHERE path = 'a.txt'`,
     );
 
     expect(res.rows.length).toBeGreaterThan(0);
@@ -787,10 +958,9 @@ describe("Incremental indexing (real DB)", () => {
 
     // ensure plan is delete-only
     const planEvent = eventBus.events
-      .filter(e => e.event === CoreEvents.WorkflowIndexPlanComputed)
+      .filter((e) => e.event === CoreEvents.WorkflowIndexPlanComputed)
       .at(-1);
 
     expect(planEvent?.fields?.type).toBe("delete-only");
   });
-
 });

--- a/packages/workflows/src/index/__tests__/incremental.test.ts
+++ b/packages/workflows/src/index/__tests__/incremental.test.ts
@@ -40,7 +40,7 @@ describe("Incremental indexing (real DB)", () => {
     }
   });
 
-  it.only("re-indexes only changed file", async () => {
+  it("re-indexes only changed file", async () => {
     const eventBus = new TestEventBus();
 
     // ---- initial commit ----

--- a/packages/workflows/src/index/__tests__/incrementalAstChunking.test.ts
+++ b/packages/workflows/src/index/__tests__/incrementalAstChunking.test.ts
@@ -1,0 +1,380 @@
+// packages/workflows/src/index/__tests__/incrementalAstChunking.test.ts
+
+import { Client } from "pg";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { CoreEvents } from "@prsense/core";
+
+import { runIndexWorkflow } from "../indexWorkflow.js";
+import {
+  createTestRepo,
+  writeFile,
+  commitAll,
+  TestEventBus,
+} from "./helper.js";
+
+import { initTestDb, resetTestDb } from "./db.js";
+import { testConfig, testCredentials } from "./config.js";
+
+const DB_CONFIG = {
+  host: "localhost",
+  port: 10001,
+  user: "prsense",
+  password: "prsense",
+  database: "prsense_test",
+};
+
+describe("AST chunking through index workflow (real DB)", () => {
+  let repo: string;
+
+  beforeAll(async () => {
+    await initTestDb();
+  });
+
+  beforeEach(async () => {
+    await resetTestDb();
+    repo = await createTestRepo();
+  });
+
+  afterEach(async () => {
+    if (repo) {
+      await fs.rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 1: Adding a top-level function produces a chunk with symbol metadata
+  // ---------------------------------------------------------------------------
+  it("indexes a top-level function and tags the chunk with its symbol name", async () => {
+    const eventBus = new TestEventBus();
+
+    await writeFile(
+      repo,
+      "auth.ts",
+      `export function login(user: string): boolean {
+  if (!user || user.length === 0) return false;
+  const trimmed = user.trim();
+  return trimmed.length > 0;
+}`,
+    );
+    commitAll(repo, "init");
+
+    const result = await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
+
+    expect(result.outcome).toBe("success");
+
+    const client = new Client(DB_CONFIG);
+    await client.connect();
+    const res = await client.query(
+      `SELECT path, content FROM rag_chunks WHERE path = 'auth.ts'`,
+    );
+    await client.end();
+
+    // At least one chunk should exist for auth.ts.
+    expect(res.rows.length).toBeGreaterThan(0);
+
+    // The chunk content should contain the function body — i.e. the AST chunker
+    // emitted the function as a coherent unit, not a fragmented split.
+    const combined = res.rows.map((r) => r.content).join("\n");
+    expect(combined).toContain("function login");
+    expect(combined).toContain("trimmed.length > 0");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2: Modifying a function's body re-indexes the file and updates content
+  // ---------------------------------------------------------------------------
+  it("re-indexes a TypeScript file when a function body changes", async () => {
+    const eventBus = new TestEventBus();
+
+    // Initial: login returns true on non-empty input.
+    await writeFile(
+      repo,
+      "auth.ts",
+      `export function login(user: string): boolean {
+  // Returns true for any non-empty user.
+  return user.length > 0;
+}`,
+    );
+    commitAll(repo, "init");
+
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
+
+    // Update: login now always returns false.
+    await writeFile(
+      repo,
+      "auth.ts",
+      `export function login(user: string): boolean {
+  // Returns false unconditionally now.
+  return false;
+}`,
+    );
+    commitAll(repo, "update login");
+
+    const result = await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
+
+    expect(result.outcome).toBe("success");
+
+    const client = new Client(DB_CONFIG);
+    await client.connect();
+    const res = await client.query(
+      `SELECT content FROM rag_chunks WHERE path = 'auth.ts'`,
+    );
+    await client.end();
+
+    const combined = res.rows.map((r) => r.content).join("\n");
+
+    // The new body should be present.
+    expect(combined).toContain("return false");
+    expect(combined).toContain("unconditionally");
+
+    // The old body should be gone.
+    expect(combined).not.toContain("user.length > 0");
+    expect(combined).not.toContain("non-empty user");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 4: Deleting a .ts file removes all of its chunks regardless of how
+  //         many symbols it contained
+  // ---------------------------------------------------------------------------
+  it("removes all chunks for a deleted TypeScript file with multiple symbols", async () => {
+    const eventBus = new TestEventBus();
+
+    // A file with multiple top-level declarations — exercises the
+    // multi-chunk path in the AST chunker.
+    await writeFile(
+      repo,
+      "session.ts",
+      `export function login(user: string): boolean {
+  if (!user || user.length === 0) return false;
+  return user.trim().length > 0;
+}
+
+export function logout(token: string): void {
+  if (!token) return;
+  console.log("logged out", token);
+}
+
+export class Session {
+  constructor(public id: string, public userId: string) {}
+  isValid(): boolean {
+    return this.id.length > 0 && this.userId.length > 0;
+  }
+}
+
+export interface SessionContext {
+  session: Session;
+  createdAt: number;
+}`,
+    );
+    commitAll(repo, "init");
+
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
+
+    // Confirm the file was indexed with multiple chunks before deletion.
+    const clientBefore = new Client(DB_CONFIG);
+    await clientBefore.connect();
+    const before = await clientBefore.query(
+      `SELECT COUNT(*) FROM rag_chunks WHERE path = 'session.ts'`,
+    );
+    await clientBefore.end();
+    expect(Number(before.rows[0].count)).toBeGreaterThan(0);
+
+    // Delete the file.
+    await fs.unlink(path.join(repo, "session.ts"));
+    commitAll(repo, "delete session");
+
+    const result = await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
+
+    expect(result.outcome).toBe("success");
+
+    // All chunks for session.ts should be gone.
+    const clientAfter = new Client(DB_CONFIG);
+    await clientAfter.connect();
+    const after = await clientAfter.query(
+      `SELECT * FROM rag_chunks WHERE path = 'session.ts'`,
+    );
+    await clientAfter.end();
+
+    expect(after.rows.length).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 6: Regression test for the chunkVersion mismatch bug.
+  //         If stored chunking.version doesn't match current CHUNK_VERSION,
+  //         the workflow must emit WorkflowIndexRebuildRequired and fail.
+  // ---------------------------------------------------------------------------
+  it("emits rebuild-required when stored chunk version does not match current", async () => {
+    const setupBus = new TestEventBus();
+
+    // Index a file at the current version.
+    await writeFile(
+      repo,
+      "auth.ts",
+      `export function login(): boolean { return true; }`,
+    );
+    commitAll(repo, "init");
+
+    const initial = await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus: setupBus,
+      version: "test",
+    });
+
+    expect(initial.outcome).toBe("success");
+
+    // Manually downgrade the stored chunking version to simulate an
+    // index built by an older PRSense.
+    const client = new Client(DB_CONFIG);
+    await client.connect();
+
+    // First, confirm metadata exists for the repo (sanity check that the
+    // initial index actually saved metadata).
+    const repoName = path.basename(repo);
+    const metaCheck = await client.query(
+      `SELECT * FROM prsense_index_metadata WHERE repository_provider = 'local' AND repository_id = $1`,
+      [repoName],
+    );
+    expect(metaCheck.rows.length).toBe(1);
+
+    // Downgrade chunking version.
+    await client.query(
+      `UPDATE prsense_index_metadata
+         SET chunk_version = 1
+       WHERE repository_provider = 'local' AND repository_id = $1`,
+      [repoName],
+    );
+    await client.end();
+
+    // Modify the file so there's something to incrementally index.
+    await writeFile(
+      repo,
+      "auth.ts",
+      `export function login(): boolean { return false; }`,
+    );
+    commitAll(repo, "update");
+
+    // Run without force. Should detect incompatibility and refuse.
+    const eventBus = new TestEventBus();
+    const result = await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      eventBus,
+      version: "test",
+    });
+
+    expect(result.outcome).toBe("failure");
+
+    const events = eventBus.events.map((e) => e.event);
+    expect(events).toContain(CoreEvents.WorkflowIndexRebuildRequired);
+
+    // The rebuild-required event should not have `forced: true` — this is
+    // the user-must-rebuild path, not the auto-rebuild-on-force path.
+    const rebuildEvent = eventBus.events.find(
+      (e) => e.event === CoreEvents.WorkflowIndexRebuildRequired,
+    );
+    expect(rebuildEvent?.fields?.forced).not.toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 6b: Companion to Test 6 — with --force, the workflow proceeds and
+  //          rebuilds successfully despite the version mismatch.
+  // ---------------------------------------------------------------------------
+  it("rebuilds when chunking version mismatches and --force is set", async () => {
+    const setupBus = new TestEventBus();
+
+    await writeFile(
+      repo,
+      "auth.ts",
+      `export function login(): boolean { return true; }`,
+    );
+    commitAll(repo, "init");
+
+    await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus: setupBus,
+      version: "test",
+    });
+
+    // Downgrade stored version.
+    const client = new Client(DB_CONFIG);
+    await client.connect();
+    const repoName = path.basename(repo);
+    await client.query(
+      `UPDATE prsense_index_metadata
+         SET chunk_version = 1
+       WHERE repository_provider = 'local' AND repository_id = $1`,
+      [repoName],
+    );
+    await client.end();
+
+    // Run WITH force. Should rebuild instead of failing.
+    const eventBus = new TestEventBus();
+    const result = await runIndexWorkflow({
+      target: repo,
+      config: testConfig(),
+      credentials: testCredentials(),
+      force: true,
+      eventBus,
+      version: "test",
+    });
+
+    expect(result.outcome).toBe("success");
+
+    // The forced rebuild path emits WorkflowIndexRebuildRequired with
+    // forced: true.
+    const rebuildEvent = eventBus.events.find(
+      (e) => e.event === CoreEvents.WorkflowIndexRebuildRequired,
+    );
+    expect(rebuildEvent?.fields?.forced).toBe(true);
+
+    // And chunks should be present after the rebuild.
+    const clientAfter = new Client(DB_CONFIG);
+    await clientAfter.connect();
+    const res = await clientAfter.query(
+      `SELECT * FROM rag_chunks WHERE path = 'auth.ts'`,
+    );
+    await clientAfter.end();
+
+    expect(res.rows.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/workflows/src/index/__tests__/incrementalAstChunking.test.ts
+++ b/packages/workflows/src/index/__tests__/incrementalAstChunking.test.ts
@@ -233,13 +233,10 @@ export interface SessionContext {
 
   // ---------------------------------------------------------------------------
   // Test 6: Regression test for the chunkVersion mismatch bug.
-  //         If stored chunking.version doesn't match current CHUNK_VERSION,
-  //         the workflow must emit WorkflowIndexRebuildRequired and fail.
   // ---------------------------------------------------------------------------
   it("emits rebuild-required when stored chunk version does not match current", async () => {
     const setupBus = new TestEventBus();
 
-    // Index a file at the current version.
     await writeFile(
       repo,
       "auth.ts",
@@ -258,30 +255,28 @@ export interface SessionContext {
 
     expect(initial.outcome).toBe("success");
 
-    // Manually downgrade the stored chunking version to simulate an
-    // index built by an older PRSense.
     const client = new Client(DB_CONFIG);
     await client.connect();
 
-    // First, confirm metadata exists for the repo (sanity check that the
-    // initial index actually saved metadata).
-    const repoName = path.basename(repo);
-    const metaCheck = await client.query(
-      `SELECT * FROM prsense_index_metadata WHERE repository_provider = 'local' AND repository_id = $1`,
-      [repoName],
+    // Discover what identity the workflow actually stored, rather than guessing.
+    const metaRows = await client.query(
+      `SELECT repository_provider, repository_id, chunk_version
+       FROM prsense_index_metadata`,
     );
-    expect(metaCheck.rows.length).toBe(1);
+    expect(metaRows.rows.length).toBe(1);
 
-    // Downgrade chunking version.
+    const stored = metaRows.rows[0];
+
+    // Downgrade chunk version on the row we just found.
     await client.query(
       `UPDATE prsense_index_metadata
-         SET chunk_version = 1
-       WHERE repository_provider = 'local' AND repository_id = $1`,
-      [repoName],
+        SET chunk_version = 1
+      WHERE repository_provider = $1 AND repository_id = $2`,
+      [stored.repository_provider, stored.repository_id],
     );
     await client.end();
 
-    // Modify the file so there's something to incrementally index.
+    // Modify the file so the workflow has something to do.
     await writeFile(
       repo,
       "auth.ts",
@@ -289,7 +284,6 @@ export interface SessionContext {
     );
     commitAll(repo, "update");
 
-    // Run without force. Should detect incompatibility and refuse.
     const eventBus = new TestEventBus();
     const result = await runIndexWorkflow({
       target: repo,
@@ -304,8 +298,6 @@ export interface SessionContext {
     const events = eventBus.events.map((e) => e.event);
     expect(events).toContain(CoreEvents.WorkflowIndexRebuildRequired);
 
-    // The rebuild-required event should not have `forced: true` — this is
-    // the user-must-rebuild path, not the auto-rebuild-on-force path.
     const rebuildEvent = eventBus.events.find(
       (e) => e.event === CoreEvents.WorkflowIndexRebuildRequired,
     );
@@ -313,8 +305,7 @@ export interface SessionContext {
   });
 
   // ---------------------------------------------------------------------------
-  // Test 6b: Companion to Test 6 — with --force, the workflow proceeds and
-  //          rebuilds successfully despite the version mismatch.
+  // Test 6b: With --force, the workflow rebuilds despite the version mismatch.
   // ---------------------------------------------------------------------------
   it("rebuilds when chunking version mismatches and --force is set", async () => {
     const setupBus = new TestEventBus();
@@ -335,19 +326,24 @@ export interface SessionContext {
       version: "test",
     });
 
-    // Downgrade stored version.
     const client = new Client(DB_CONFIG);
     await client.connect();
-    const repoName = path.basename(repo);
+
+    const metaRows = await client.query(
+      `SELECT repository_provider, repository_id
+       FROM prsense_index_metadata`,
+    );
+    expect(metaRows.rows.length).toBe(1);
+    const stored = metaRows.rows[0];
+
     await client.query(
       `UPDATE prsense_index_metadata
-         SET chunk_version = 1
-       WHERE repository_provider = 'local' AND repository_id = $1`,
-      [repoName],
+        SET chunk_version = 1
+      WHERE repository_provider = $1 AND repository_id = $2`,
+      [stored.repository_provider, stored.repository_id],
     );
     await client.end();
 
-    // Run WITH force. Should rebuild instead of failing.
     const eventBus = new TestEventBus();
     const result = await runIndexWorkflow({
       target: repo,
@@ -360,14 +356,11 @@ export interface SessionContext {
 
     expect(result.outcome).toBe("success");
 
-    // The forced rebuild path emits WorkflowIndexRebuildRequired with
-    // forced: true.
     const rebuildEvent = eventBus.events.find(
       (e) => e.event === CoreEvents.WorkflowIndexRebuildRequired,
     );
     expect(rebuildEvent?.fields?.forced).toBe(true);
 
-    // And chunks should be present after the rebuild.
     const clientAfter = new Client(DB_CONFIG);
     await clientAfter.connect();
     const res = await clientAfter.query(

--- a/packages/workflows/src/index/indexWorkflow.ts
+++ b/packages/workflows/src/index/indexWorkflow.ts
@@ -138,9 +138,9 @@ export async function runIndexWorkflow({
     const incompatibilityReasons: string[] = [];
 
     if (stored) {
-      if (!stored.chunking || stored.chunking.version !== 2) {
+      if (!stored.chunking || stored.chunking.version !== 3) {
         incompatibilityReasons.push(
-          `chunking version changed (${stored.chunking?.version ?? "unknown"} → 2)`,
+          `chunking version changed (${stored.chunking?.version ?? "unknown"} → 3)`,
         );
       }
 

--- a/packages/workflows/src/index/indexWorkflow.ts
+++ b/packages/workflows/src/index/indexWorkflow.ts
@@ -3,7 +3,7 @@ import { CoreEvents, EventBus, ContextChunk } from "@prsense/core";
 import {
   PostgresIndexMetadataRepository,
   PostgresRagChunkRepository,
-  createCharChunker,
+  createCompositeChunker,
 } from "@prsense/context";
 import type { IndexWorkflowResult } from "./types.js";
 import type { ResolvedConfig, CredentialContext } from "@prsense/config";
@@ -132,7 +132,7 @@ export async function runIndexWorkflow({
       embeddingModel: config.embeddings.model,
       embeddingDimension,
       chunkStrategy: "default",
-      chunkVersion: 2,
+      chunkVersion: 3,
     };
 
     const incompatibilityReasons: string[] = [];
@@ -290,7 +290,7 @@ export async function runIndexWorkflow({
           },
           chunking: {
             strategy: "default",
-            version: 2,
+            version: 3,
           },
           prsenseVersion: version,
           createdAt: new Date().toISOString(),
@@ -354,7 +354,7 @@ export async function runIndexWorkflow({
             },
             chunking: {
               strategy: "default",
-              version: 2,
+              version: 3,
             },
             prsenseVersion: version,
             createdAt: new Date().toISOString(),
@@ -372,9 +372,11 @@ export async function runIndexWorkflow({
           };
         }
 
-        const chunker = createCharChunker({
-          maxChars: config.index.chunkSizeChars,
-          overlapChars: config.index.chunkOverlapChars,
+        const chunker = createCompositeChunker({
+          char: {
+            maxChars: config.index.chunkSizeChars,
+            overlapChars: config.index.chunkOverlapChars,
+          },
         });
 
         const chunks: ContextChunk[] = await buildChunks({
@@ -477,7 +479,7 @@ export async function runIndexWorkflow({
           },
           chunking: {
             strategy: "default",
-            version: 2,
+            version: 3,
           },
           prsenseVersion: version,
           createdAt: new Date().toISOString(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       pg:
         specifier: ^8.17.1
         version: 8.17.1
+      ts-morph:
+        specifier: ^28.0.0
+        version: 28.0.0
     devDependencies:
       '@types/node':
         specifier: ^25.0.3
@@ -1208,6 +1211,9 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -1490,6 +1496,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.19:
     resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
     engines: {node: '>=6.0.0'}
@@ -1507,6 +1517,10 @@ packages:
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1616,6 +1630,9 @@ packages:
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
@@ -2425,6 +2442,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -2569,6 +2590,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3078,6 +3102,9 @@ packages:
         optional: true
       jest-util:
         optional: true
+
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -4176,6 +4203,12 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@ts-morph/common@0.29.0':
+    dependencies:
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.16
+
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -4447,6 +4480,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.19: {}
 
   before-after-hook@4.0.0: {}
@@ -4463,6 +4498,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4561,6 +4600,8 @@ snapshots:
       mimic-response: 1.0.1
 
   co@4.6.0: {}
+
+  code-block-writer@13.0.3: {}
 
   collect-v8-coverage@1.0.3: {}
 
@@ -5530,6 +5571,10 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
@@ -5655,6 +5700,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -6132,6 +6179,11 @@ snapshots:
       '@jest/types': 30.3.0
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
+
+  ts-morph@28.0.0:
+    dependencies:
+      '@ts-morph/common': 0.29.0
+      code-block-writer: 13.0.3
 
   ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      ts-morph:
+        specifier: ^28.0.0
+        version: 28.0.0
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
@@ -147,6 +150,9 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      ts-morph:
+        specifier: ^28.0.0
+        version: 28.0.0
       yaml:
         specifier: ^2.8.2
         version: 2.8.2


### PR DESCRIPTION
Uses ts-morph to split modules into usable chunks with defined limits. Chunks outside defined limits are merged or broken down to observe the limits.