### PR TITLE
Chore/harden init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to PRSense are documented here.
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0
+
+### Changed
+
+- `prsense init` now configures a single provider for both review and embeddings.
+  Choices: Ollama, OpenAI, Google.
+- API keys are now written to `.env` in the current directory instead of printed
+  as shell `export` instructions.
+- Updated default models to current recommendations:
+  - OpenAI: `gpt-5.4-mini` (review), `text-embedding-3-small` (embeddings)
+  - Google: `gemini-2.5-flash` (review), `gemini-embedding-001` (embeddings)
+  - Ollama: unchanged
+
+### Removed
+
+- Anthropic dropped from `prsense init` choices. Anthropic has no embeddings API,
+  so single-key setup isn't possible. Users who want Claude for review can still
+  configure it manually in `prsense.yml` alongside a separate embeddings provider.
+
+### Added
+
+- Google embeddings provider (`gemini-embedding-001` via `@google/generative-ai`).
+
 ## 0.8.2
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to PRSense are documented here.
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.2
+
+### Changed
+
+- manpage is now automatically installed on `npm i -g @prsense/cli`
+
 ## 0.8.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,14 +167,6 @@ prsense index . --dry-run
 prsense index . --stats
 ```
 
-#### Run setup checks
-
-```bash
-prsense setup
-```
-
-Ensures required infrastructure (database, embeddings, etc.) is available.
-
 ### Daemon Mode
 
 The daemon runs PRSense as a long-lived HTTP service, intended for automation and webhook-based review. It is distributed as a separate package.

--- a/apps/cli/src/commands/init/runFirstTimeSetup.ts
+++ b/apps/cli/src/commands/init/runFirstTimeSetup.ts
@@ -1,9 +1,39 @@
 // apps/cli/src/commands/init/runFirstTimeSetup.ts
 import prompts from "prompts";
 import fs from "fs";
+import path from "path";
 import yaml from "yaml";
 import { CONFIG_PATH, PRSENSE_CONFIG_DIR } from "@prsense/core";
 import { defaults as DEFAULT_CONFIG } from "@prsense/config";
+
+const ENV_FILE = path.join(process.cwd(), ".env");
+
+/**
+ * Upsert a single KEY=value pair in .env at process.cwd().
+ * Preserves other lines; replaces in-place if key already exists.
+ * Returns true if a new line was appended, false if an existing line was replaced.
+ */
+function upsertEnvVar(key: string, value: string): boolean {
+  const line = `${key}=${value}`;
+  const existing = fs.existsSync(ENV_FILE)
+    ? fs.readFileSync(ENV_FILE, "utf8")
+    : "";
+
+  const lines = existing.split("\n");
+  const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+
+  let appended = false;
+  if (idx >= 0) {
+    lines[idx] = line;
+  } else {
+    if (existing.length && !existing.endsWith("\n")) lines.push("");
+    lines.push(line);
+    appended = true;
+  }
+
+  fs.writeFileSync(ENV_FILE, lines.join("\n").replace(/\n+$/, "\n"));
+  return appended;
+}
 
 type Provider = "ollama" | "openai" | "google";
 
@@ -98,8 +128,10 @@ export async function runFirstTimeSetup() {
       const envVar = getEnvVarName(provider);
       process.env[envVar] = apiKey;
 
-      console.log("👉 Add this to your shell:\n");
-      console.log(`export ${envVar}=${apiKey}\n`);
+      const appended = upsertEnvVar(envVar, apiKey);
+      console.log(
+        `✔ ${appended ? "Wrote" : "Updated"} ${envVar} in ${ENV_FILE}\n`,
+      );
     } catch (err: any) {
       console.log(`✖ ${err.message}\n`);
       process.exit(1);

--- a/apps/cli/src/commands/init/runFirstTimeSetup.ts
+++ b/apps/cli/src/commands/init/runFirstTimeSetup.ts
@@ -1,15 +1,22 @@
+// apps/cli/src/commands/init/runFirstTimeSetup.ts
 import prompts from "prompts";
 import fs from "fs";
 import yaml from "yaml";
 import { CONFIG_PATH, PRSENSE_CONFIG_DIR } from "@prsense/core";
 import { defaults as DEFAULT_CONFIG } from "@prsense/config";
 
-type Provider = "ollama" | "openai" | "anthropic" | "google";
-const DEFAULT_MODELS: Record<Provider, string> = {
+type Provider = "ollama" | "openai" | "google";
+
+const DEFAULT_LLM_MODELS: Record<Provider, string> = {
   ollama: "deepseek-coder-v2",
   openai: "gpt-4o-mini",
-  anthropic: "claude-3-5-sonnet-latest",
   google: "gemini-1.5-pro",
+};
+
+const DEFAULT_EMBEDDING_MODELS: Record<Provider, string> = {
+  ollama: "nomic-embed-text",
+  openai: "text-embedding-3-small",
+  google: "text-embedding-004",
 };
 
 export async function runFirstTimeSetup() {
@@ -25,16 +32,24 @@ export async function runFirstTimeSetup() {
     {
       type: "select",
       name: "provider",
-      message: "Choose LLM provider:",
+      message: "Choose provider (used for both review and embeddings):",
       choices: [
         { title: "Ollama (local)", value: "ollama" },
         { title: "OpenAI", value: "openai" },
-        { title: "Anthropic", value: "anthropic" },
         { title: "Google", value: "google" },
       ],
     },
     { onCancel },
   )) as { provider: Provider };
+
+  console.log(
+    "\nℹ Anthropic isn't offered here because it has no embeddings API.",
+  );
+  console.log(
+    "  To use Claude for review, finish setup with another provider and",
+    "edit your config to mix providers (e.g. Claude for review + Voyage",
+    "for embeddings).\n",
+  );
 
   let apiKey: string | null = null;
 
@@ -60,8 +75,12 @@ export async function runFirstTimeSetup() {
   const config = structuredClone(DEFAULT_CONFIG);
 
   config.llm.provider = provider;
-  config.llm.model = DEFAULT_MODELS[provider];
-  console.log(`✔ Using model: ${config.llm.model}\n`);
+  config.llm.model = DEFAULT_LLM_MODELS[provider];
+  config.embeddings.provider = provider;
+  config.embeddings.model = DEFAULT_EMBEDDING_MODELS[provider];
+
+  console.log(`✔ LLM model:        ${config.llm.model}`);
+  console.log(`✔ Embeddings model: ${config.embeddings.model}\n`);
 
   // ✅ print config (dev trust boost)
   console.log("\n---");
@@ -99,8 +118,6 @@ function getEnvVarName(provider: Provider): string {
   switch (provider) {
     case "openai":
       return "PRSENSE_OPENAI_API_KEY";
-    case "anthropic":
-      return "PRSENSE_ANTHROPIC_API_KEY";
     case "google":
       return "PRSENSE_GOOGLE_API_KEY";
     default:
@@ -120,18 +137,6 @@ async function validateApiKey(
         const res = await fetch("https://api.openai.com/v1/models", {
           headers: {
             Authorization: `Bearer ${apiKey}`,
-          },
-        });
-
-        if (!res.ok) throw new Error(await extractError(res));
-        return;
-      }
-
-      case "anthropic": {
-        const res = await fetch("https://api.anthropic.com/v1/models", {
-          headers: {
-            "x-api-key": apiKey,
-            "anthropic-version": "2023-06-01",
           },
         });
 

--- a/apps/cli/src/commands/init/runFirstTimeSetup.ts
+++ b/apps/cli/src/commands/init/runFirstTimeSetup.ts
@@ -9,14 +9,14 @@ type Provider = "ollama" | "openai" | "google";
 
 const DEFAULT_LLM_MODELS: Record<Provider, string> = {
   ollama: "deepseek-coder-v2",
-  openai: "gpt-4o-mini",
-  google: "gemini-1.5-pro",
+  openai: "gpt-5.4-mini",
+  google: "gemini-2.5-flash",
 };
 
 const DEFAULT_EMBEDDING_MODELS: Record<Provider, string> = {
   ollama: "nomic-embed-text",
   openai: "text-embedding-3-small",
-  google: "text-embedding-004",
+  google: "gemini-embedding-001",
 };
 
 export async function runFirstTimeSetup() {

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -5,4 +5,4 @@ export * from "./providers/anthropic.js";
 export * from "./providers/google.js";
 export * from "./providers/ollamaEmbeddings.js";
 export * from "./providers/openaiEmbeddings.js";
-//TODO add gemini embeddings client if available
+export * from "./providers/googleEmbeddings.js";

--- a/packages/llm/src/providers/googleEmbeddings.ts
+++ b/packages/llm/src/providers/googleEmbeddings.ts
@@ -1,0 +1,40 @@
+// packages/llm/src/providers/googleEmbeddings.ts
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import type { EmbeddingClient } from "../types.js";
+
+export function createGoogleEmbeddingClient(opts: {
+  apiKey: string;
+  model: string;
+}): EmbeddingClient {
+  const genAI = new GoogleGenerativeAI(opts.apiKey);
+  const model = genAI.getGenerativeModel({ model: opts.model });
+
+  let cachedDimension: number | null = null;
+
+  async function embed(texts: string[]): Promise<number[][]> {
+    if (!texts.length) return [];
+
+    const response = await model.batchEmbedContents({
+      requests: texts.map((text) => ({
+        content: { role: "user", parts: [{ text }] },
+      })),
+    });
+
+    return response.embeddings.map((e) => e.values);
+  }
+
+  async function detectDimension(): Promise<number> {
+    if (cachedDimension !== null) return cachedDimension;
+    const vectors = await embed(["dimension test"]);
+    if (!vectors.length || !vectors[0]) {
+      throw new Error("Failed to detect embedding dimension: empty response");
+    }
+    cachedDimension = vectors[0].length;
+    return cachedDimension;
+  }
+
+  return {
+    embed,
+    dimension: detectDimension,
+  };
+}

--- a/packages/workflows/src/index/__tests__/setup.ts
+++ b/packages/workflows/src/index/__tests__/setup.ts
@@ -1,17 +1,21 @@
-
+// packages/workflows/src/index/__tests__/setup.ts
 jest.mock("@prsense/llm", () => ({
   createOpenAiEmbeddingClient: () => ({
     dimension: async () => 768,
-    embed: async (texts: string[]) =>
-      texts.map(() => Array(768).fill(0.1)),
+    embed: async (texts: string[]) => texts.map(() => Array(768).fill(0.1)),
   }),
   createOllamaEmbeddingClient: () => ({
     dimension: async () => 768,
-    embed: async (texts: string[]) =>
-      texts.map(() => Array(768).fill(0.1)),
+    embed: async (texts: string[]) => texts.map(() => Array(768).fill(0.1)),
+  }),
+
+  createGoogleEmbeddingClient: () => ({
+    dimension: async () => 768,
+    embed: async (texts: string[]) => texts.map(() => Array(768).fill(0.1)),
   }),
 }));
 
 jest.mock("@octokit/rest", () => ({
-  Octokit: function () { },
+  Octokit: function () {},
 }));
+

--- a/packages/workflows/src/index/indexWorkflow.ts
+++ b/packages/workflows/src/index/indexWorkflow.ts
@@ -10,6 +10,7 @@ import type { ResolvedConfig, CredentialContext } from "@prsense/config";
 import {
   createOpenAiEmbeddingClient,
   createOllamaEmbeddingClient,
+  createGoogleEmbeddingClient,
 } from "@prsense/llm";
 import {
   resolveRepositorySource,
@@ -96,8 +97,17 @@ export async function runIndexWorkflow({
         apiKey,
         model: config.embeddings.model,
       });
-    } else {
+    } else if (config.embeddings.provider === "ollama") {
       embeddingClient = createOllamaEmbeddingClient({
+        model: config.embeddings.model,
+      });
+    } else {
+      const apiKey = credentials.google?.apiKey;
+      if (!apiKey) {
+        throw new Error("Google embedding credentials missing");
+      }
+      embeddingClient = createGoogleEmbeddingClient({
+        apiKey,
         model: config.embeddings.model,
       });
     }

--- a/test-prsense.zsh
+++ b/test-prsense.zsh
@@ -1,0 +1,9 @@
+#!/usr/bin/env zsh
+
+sandbox=$(mktemp -d)
+echo "sandbox: $sandbox"
+
+HOME=$sandbox \
+XDG_CONFIG_HOME=$sandbox/.config \
+XDG_DATA_HOME=$sandbox/.local/share \
+  zsh -i


### PR DESCRIPTION
Now the init commands defaults to a single provider for both embeddings / review.
Note: since anthropic doesn't provide a default embeddings generation endpoint, it's dropped as a provider from `init` and can be setup later in config.