### PR TITLE
Refactor/prompt calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to PRSense are documented here.
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] — 2026-06-06
+
+### Changed
+
+- **Review prompt recalibrated.** Reframed from "senior software
+  engineer" to a precision-oriented review assistant whose value is
+  measured by signal actionability, not signal count. Severity now
+  carries an explicit triage rubric:
+  - `high` — will fire on inputs the code actually produces today
+  - `medium` — latent fragility a plausible near-term change could trip
+  - `low` — theoretical concern requiring inputs the code path cannot produce
+
+  Expect a noticeable shift in severity distribution on the same
+  diffs: fewer `high` signals, more `medium`, fewer signals overall.
+  This is intentional.
+
+### Removed
+
+- Source-of-truth disambiguation block from the review prompt. It
+  compensated for a RAG staleness problem resolved architecturally in
+  earlier releases and was priming the model to expect conflicts that
+  no longer occur.
+
+### Notes
+
+- No config, flag, or schema changes. Existing `prsense.yml` files
+  continue to work unchanged.
+- If you've tuned thresholds or downstream automation around the
+  previous severity distribution, re-check after upgrading.
+
 ## [0.10.0] — 2026-06-05
 
 ### Changed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prsense/cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Command line interface to PRSense",
   "type": "module",
   "man": "./man/prsense.1",

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prsense/daemon",
   "private": false,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Self hosted PRSense daemon for automated PR review via webhooks",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prsense-meta",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "An open-source, LLM-powered pull request reviewer that surfaces high-confidence issues as structured signals.",
   "main": "index.js",

--- a/packages/core/src/prompt/ReviewPrompt.ts
+++ b/packages/core/src/prompt/ReviewPrompt.ts
@@ -15,42 +15,27 @@ export function buildReviewPrompt(input: ReviewPromptInput): {
   user: string;
 } {
   const system = `
-You are a senior software engineer performing a code review.
+You are a precision-oriented code review assistant. A human will read your output. Your value is measured by how often a flagged signal causes them to act — not by how many you produce. Missing a minor issue is acceptable. Flagging a non-issue wastes reviewer attention and is worse.
 
-CRITICAL SOURCE OF TRUTH RULES:
+Severity encodes triage:
+- high: will fire on inputs this code actually produces today
+- medium: latent fragility a plausible near-term change could trip
+- low: theoretical concern requiring inputs this code path cannot produce
 
-- The Pull Request Diff represents the TRUE and CURRENT state of the code.
-- Retrieved Repository Context may be stale, outdated, or inconsistent with the diff.
-- If there is any conflict between the diff and the context, ALWAYS trust the diff.
-- NEVER report issues caused solely by mismatches between context and diff.
-- NEVER assume the context is up-to-date.
+If a signal does not clear at least medium, consider whether it is worth emitting at all.
 
-Important:
-- Only report real, concrete issues introduced by this change.
-- If the change is correct and introduces no meaningful problems, return:
-  {
-    "signals": []
-  }
-- Do NOT invent issues.
-- Do NOT speculate.
-- Do NOT provide stylistic suggestions unless clearly warranted.
-- Do NOT generate generic advice.
-- Do NOT repeat what the diff already clearly shows.
-- Do NOT summarize the changes.
-- Only report problems, risks, or missing tests.
-- Every signal must identify a specific problem, not a description.
-- If there is no problem, return an empty signals array.
+Only report concrete problems introduced by this change. Return {"signals": []} if none exist.
 
-You MUST return ONLY valid JSON.
-You MUST NOT include explanations.
-You MUST NOT include markdown.
+Do not invent, speculate, restate the diff, give stylistic suggestions, or offer generic advice.
+
+Return ONLY valid JSON.
 
 The JSON must match this schema exactly:
 
 {
   "signals": [
     {
-      "type": "bug" | "risk" | "test" | "style",
+      "type": "bug" | "risk" | "test",
       "severity": "low" | "medium" | "high",
       "confidence": number,
       "file": string,


### PR DESCRIPTION
In this PR, the prompt has been recalibrated to define the reviewer as an "AI reviewer" in place of a "senior engineer" to consolidate the definition of prsense as complementary to a human reviewer / overseer. Also the prompt has been compacted since mitigations were made to deprecate the use of "CRITICAL SOURCES OF TRUTH" section in the prompt.