### PR TITLE
Refactor/rename misleading max signals config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to PRSense are documented here.
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] — 2026-06-10
+
+### Breaking
+
+- review.maxSignals renamed to review.topSignals; CLI flag --max-signals → --top-signals
+
 ## [0.11.2] — 2026-06-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ index:
 
 review:
   confidenceThreshold: 0.8
-  maxSignals: 3
+  topSignals: 3
 
 context:
   maxChunks: 5
@@ -429,7 +429,7 @@ Controls repository chunking.
 Controls signal filtering.
 
 - `confidenceThreshold` — minimum confidence.
-- `maxSignals` — maximum number of emitted signals.
+- `topSignals` — number of highest risk emitted signals.
 
 ## `context`
 

--- a/apps/cli/man/prsense.1
+++ b/apps/cli/man/prsense.1
@@ -412,7 +412,7 @@ embeddings:
 
 review:
   confidenceThreshold: 0.8
-  maxSignals: 3
+  topSignals: 3
 
 index:
   auto: true

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prsense/cli",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Command line interface to PRSense",
   "type": "module",
   "man": "./man/prsense.1",

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -31,7 +31,7 @@ const PRSENSE_VERSION = pkg.version;
 export const reviewCommand = new Command("review")
   .argument("[target]", "Path to repository", ".")
   .option("-b, --base-branch <branch>", "Base branch to diff against")
-  .option("-n, --top-signals <n>", "Maximum number of signals requested")
+  .option("-n, --top-signals <n>", "Number of highest risk signals to display")
   .option(
     "-c, --max-chunks <n>",
     "Maximum number of indexed chunks to retrieve for context",

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -31,7 +31,7 @@ const PRSENSE_VERSION = pkg.version;
 export const reviewCommand = new Command("review")
   .argument("[target]", "Path to repository", ".")
   .option("-b, --base-branch <branch>", "Base branch to diff against")
-  .option("-n, --max-signals <n>", "Maximum number of signals requested")
+  .option("-n, --top-signals <n>", "Maximum number of signals requested")
   .option(
     "-c, --max-chunks <n>",
     "Maximum number of indexed chunks to retrieve for context",

--- a/apps/cli/src/shared/configOverride.ts
+++ b/apps/cli/src/shared/configOverride.ts
@@ -45,7 +45,7 @@ export function buildOverrides(options: any) {
       temperature: options.llmTemperature,
     },
     review: {
-      maxSignals: options.maxSignals,
+      topSignals: options.topSignals,
       confidenceThreshold: options.confidenceThreshold,
     },
     context: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prsense-meta",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "description": "An open-source, LLM-powered pull request reviewer that surfaces high-confidence issues as structured signals.",
   "main": "index.js",

--- a/packages/bench/src/benchConfig.ts
+++ b/packages/bench/src/benchConfig.ts
@@ -21,7 +21,7 @@ export const benchConfig: ResolvedConfig = {
 
   review: {
     confidenceThreshold: 0.6,
-    maxSignals: 10,
+    topSignals: 10,
   },
 
   index: {

--- a/packages/config/src/__tests__/schema.test.ts
+++ b/packages/config/src/__tests__/schema.test.ts
@@ -93,7 +93,7 @@ describe("ResolvedConfigSchema", () => {
   it("parses {} into the full default config", () => {
     const parsed = RuntimeConfigSchema.parse({});
     expect(parsed.review.confidenceThreshold).toBe(0.8);
-    expect(parsed.review.maxSignals).toBe(3);
+    expect(parsed.review.topSignals).toBe(3);
     expect(parsed.context.maxChunks).toBe(5);
     expect(parsed.git.baseBranch).toBe("main");
     expect(parsed.llm.provider).toBe("ollama");

--- a/packages/config/src/__tests__/validateCredentials.test.ts
+++ b/packages/config/src/__tests__/validateCredentials.test.ts
@@ -9,7 +9,7 @@ const cliCfg = (overrides: Partial<any> = {}): ResolvedConfig =>
     llm: { provider: "ollama", model: "x", temperature: 0.1 },
     embeddings: { provider: "ollama", model: "x" },
     index: { chunkSizeChars: 1000, chunkOverlapChars: 200, auto: true },
-    review: { confidenceThreshold: 0.8, maxSignals: 3 },
+    review: { confidenceThreshold: 0.8, topSignals: 3 },
     context: { maxChunks: 5 },
     git: { baseBranch: "main" },
     logLevel: "warn",

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -33,7 +33,7 @@ const IndexConfigSchema = z
 const ReviewConfigSchema = z
   .object({
     confidenceThreshold: z.number().min(0).max(1).default(0.8),
-    maxSignals: z.number().int().positive().default(3),
+    topSignals: z.number().int().positive().default(3),
   })
   .prefault({});
 

--- a/packages/workflows/src/review/steps/finaliseSignals.ts
+++ b/packages/workflows/src/review/steps/finaliseSignals.ts
@@ -28,7 +28,7 @@ export function finalizeSignals(
     return sev !== 0 ? sev : b.confidence - a.confidence;
   });
 
-  const signals = ranked.slice(0, config.review.maxSignals);
+  const signals = ranked.slice(0, config.review.topSignals);
 
   eventBus.emit(CoreEvents.SignalCompiled, {
     count: signals.length,

--- a/prsense.yml
+++ b/prsense.yml
@@ -9,7 +9,7 @@ embeddings:
 
 review:
   confidenceThreshold: 0.8
-  maxSignals: 3
+  topSignals: 3
 
 index:
   auto: true


### PR DESCRIPTION
--max-signals is misleading because prsense generates all the available signals and only chooses to display <n> of them. Now it is renamed to --top-signals