### PR TITLE
Feat/specify default base branch init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to PRSense are documented here.
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] — 2026-06-18
+
+### Changed
+
+- `prsense init` now prompts for the default base branch (prefilled with
+  `main`) and writes it to `git.baseBranch` in the generated config.
+
 ## [0.15.1] — 2026-06-17
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prsense/cli",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Command line interface to PRSense",
   "type": "module",
   "man": "./man/prsense.1",

--- a/apps/cli/src/commands/init/runFirstTimeSetup.ts
+++ b/apps/cli/src/commands/init/runFirstTimeSetup.ts
@@ -51,10 +51,22 @@ export async function runFirstTimeSetup() {
     { onCancel },
   )) as { provider: InitProvider };
 
+  const { baseBranch } = (await prompts(
+    {
+      type: "text",
+      name: "baseBranch",
+      message: "Default base branch:",
+      initial: "main",
+      validate: (v: string) => (v.trim().length > 0 ? true : "Required"),
+    },
+    { onCancel },
+  )) as { baseBranch: string };
+
   // Build config through the schema — defaults fill in everything else.
   const config = RuntimeConfigSchema.parse({
     llm: { provider, model: DEFAULT_LLM_MODELS[provider] },
     embeddings: { provider, model: DEFAULT_EMBEDDING_MODELS[provider] },
+    git: { baseBranch: baseBranch.trim() },
   });
 
   console.log(`✔ LLM model:        ${config.llm.model}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prsense-meta",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "private": true,
   "description": "Code reviewer that surfaces high risk signals from diff",
   "main": "index.js",


### PR DESCRIPTION
For comprehensiveness, `prsense init` now asks for the baseBranch config variable with "main" as default.