### PR TITLE
Fix/repo root determination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to PRSense are documented here.
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.4] — 2026-06-19
+
+### Fixed
+
+- **Repo root resolution from subdirectories.** Every CLI command
+  (`review`, `index`, `config inspect`, `doctor`) was deriving the
+  repository root from `process.cwd()` rather than the actual git root.
+  Running from any subdirectory silently fell back to default
+  configuration (`baseBranch: main`), bypassing `prsense.yml` and
+  triggering `git rev-parse` / `git diff` failures against the
+  configured base branch. Root is now resolved via
+  `git rev-parse --show-toplevel`.
+
+### Changed
+
+- **Target classification centralized.** Each command previously
+  duplicated its own URL regex set and path resolution, with subtle
+  drift (e.g. `index` had no Codeberg support; `review` did). All
+  commands now route through a single `classifyTarget` helper that
+  returns a discriminated `ClassifiedTarget` union covering GitHub,
+  GitLab, Codeberg (PR/MR and bare-repo URL forms), and filesystem.
+- `runIndexWorkflow` and `resolveRepositorySource` now consume
+  `ClassifiedTarget` rather than re-parsing a raw target string.
+  URL parsing happens exactly once, at the CLI edge.
+- Review now surfaces a clear error when given a non-PR URL (e.g.
+  `github.com/org/repo` without `/pull/N`), instead of misclassifying
+  it as a local path.
+
+### Internal
+
+- `ClassifiedTarget` lives in `@prsense/core` as a pure domain type;
+  `classifyTarget` (the function, which shells out for repo-root
+  discovery) stays at the CLI edge.
+
+### Notes
+
+- Codeberg indexing dispatch is stubbed pending a follow-up PR; review
+  against Codeberg PRs is unchanged.
+
 ## [0.15.3] — 2026-06-19
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prsense/cli",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Command line interface to PRSense",
   "type": "module",
   "man": "./man/prsense.1",

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -5,6 +5,7 @@ import {
   stdoutConfigInspectReporter,
   stdoutConfigReporter,
 } from "@prsense/reporters";
+import { classifyTarget } from "../shared/classifyTarget.js";
 
 export const configCommand = new Command("config").description(
   "Inspect and manage PRSense configuration",
@@ -13,10 +14,11 @@ export const configCommand = new Command("config").description(
 configCommand
   .command("inspect")
   .description("Show resolved configuration")
-  .action(async (options) => {
+  .action(async () => {
+    const t = classifyTarget(".");
     const env = resolveEnvironment("cli", {
-      root: ".",
-      provider: "filesystem",
+      root: t.root,
+      provider: t.provider,
     });
 
     if (env.issues.some((i) => i.level === "error")) {
@@ -27,8 +29,7 @@ configCommand
     await stdoutConfigInspectReporter.report({
       config: env.config,
       credentials: env.credentials,
-      issues: env.issues, // include warnings if any
+      issues: env.issues,
     });
-
     process.exit(0);
   });

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -9,6 +9,7 @@ import { resolveEnvironment } from "@prsense/config";
 
 import { createSpinnerRenderer } from "../ui/spinnerRenderer.js";
 import { eventToCliTask } from "../ui/eventToTask.js";
+import { classifyTarget } from "../shared/classifyTarget.js";
 
 const logLevel = (process.env.PRSENSE_LOG_LEVEL as any) ?? "warn";
 
@@ -43,10 +44,12 @@ export const doctorCommand = new Command("doctor")
     });
 
     try {
+      const t = classifyTarget(".");
       const env = resolveEnvironment("cli", {
-        root: ".",
-        provider: "filesystem",
+        root: t.root,
+        provider: t.provider,
       });
+
       if (env.issues.length > 0) {
         eventBus.emit(CoreEvents.RunFailed, {
           reason: "invalid-config",

--- a/apps/cli/src/commands/index.ts
+++ b/apps/cli/src/commands/index.ts
@@ -138,7 +138,7 @@ export const indexCommand = new Command("index")
         metadataRepository: services.metadataRepo,
         config: effectiveConfig,
         credentials: env.credentials,
-        target,
+        target: t,
         force: Boolean(options.force),
         dryRun: Boolean(options.dryRun),
         eventBus,

--- a/apps/cli/src/commands/index.ts
+++ b/apps/cli/src/commands/index.ts
@@ -1,7 +1,5 @@
 // apps/cli/src/commands/index.ts
 import { Command } from "commander";
-import path from "node:path";
-
 import { runIndexWorkflow, listIndexedRepositories } from "@prsense/workflows";
 import { createPinoLogger, logEvent, LogLevel } from "@prsense/logging";
 import { createEventBus, CoreEvents } from "@prsense/core";
@@ -20,6 +18,7 @@ import {
   stdoutIndexedReposReporter,
 } from "@prsense/reporters";
 import { applyOverrides, buildOverrides } from "../shared/configOverride.js";
+import { classifyTarget } from "../shared/classifyTarget.js";
 
 import pkg from "../../package.json" with { type: "json" };
 
@@ -78,21 +77,10 @@ export const indexCommand = new Command("index")
       /* Determine Repository Provider                     */
       /* ------------------------------------------------- */
 
-      const isGithub = /github\.com/.test(target);
-      const isGitlab = /gitlab\.com/.test(target);
-
-      const repoProvider = isGithub
-        ? "github"
-        : isGitlab
-          ? "gitlab"
-          : "filesystem";
-
-      const repoRoot =
-        repoProvider === "filesystem" ? path.resolve(target) : target;
-
+      const t = classifyTarget(target);
       const env = resolveEnvironment("cli", {
-        root: repoRoot,
-        provider: repoProvider,
+        root: t.root,
+        provider: t.provider,
       });
 
       if (env.issues.some((i) => i.level === "error")) {

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -18,7 +18,6 @@ import {
   printStats,
   printSignals,
 } from "@prsense/reporters";
-import path from "node:path";
 import {
   LocalGitDiffProvider,
   GitHubPrDiffProvider,
@@ -30,7 +29,7 @@ import { ensureInit } from "./init/ensureInit.js";
 
 import pkg from "../../package.json" with { type: "json" };
 import { buildServices } from "../composition.js";
-import { findRepoRoot } from "../shared/findRepoRoot.js";
+import { classifyTarget } from "../shared/classifyTarget.js";
 
 const PRSENSE_VERSION = pkg.version;
 
@@ -95,33 +94,11 @@ export const reviewCommand = new Command("review")
       // Load Config
       // -------------------------------------------------
 
-      const githubPrMatch = target.match(
-        /github\.com\/([^\/]+)\/([^\/]+)\/pull\/(\d+)/,
-      );
-      const gitlabMrMatch = target.match(
-        /gitlab\.com\/([^\/]+)\/([^\/]+)\/-\/merge_requests\/(\d+)/,
-      );
-      const codebergPrMatch = target.match(
-        /codeberg\.org\/([^\/]+)\/([^\/]+)\/pulls\/(\d+)/,
-      );
-
-      const isUrl = githubPrMatch || gitlabMrMatch || codebergPrMatch;
-
-      const repoRoot = isUrl
-        ? path.resolve(target)
-        : findRepoRoot(path.resolve(target));
-
-      const repoProvider = githubPrMatch
-        ? "github"
-        : gitlabMrMatch
-          ? "gitlab"
-          : codebergPrMatch
-            ? "codeberg"
-            : "filesystem";
+      const t = classifyTarget(target);
 
       const env = resolveEnvironment("cli", {
-        root: repoRoot,
-        provider: repoProvider,
+        root: t.root,
+        provider: t.provider,
       });
 
       if (env.issues.some((i) => i.level === "error")) {
@@ -170,6 +147,7 @@ export const reviewCommand = new Command("review")
 
       if (options.autoIndex) {
         try {
+          //TODO: move away from passing raw target here
           await runIndexWorkflow({
             config: effectiveConfig,
             credentials: env.credentials,
@@ -197,36 +175,22 @@ export const reviewCommand = new Command("review")
 
       console.log("→ Running review...\n");
 
-      let diffProvider;
-
-      if (githubPrMatch) {
-        const [, owner, repo, prNumber] = githubPrMatch;
-        diffProvider = new GitHubPrDiffProvider(
-          owner,
-          repo.replace(".git", ""),
-          prNumber,
-        );
-      } else if (gitlabMrMatch) {
-        const [, group, project, mrNumber] = gitlabMrMatch;
-        diffProvider = new GitLabMrDiffProvider(
-          group,
-          project.replace(".git", ""),
-          mrNumber,
-        );
-      } else if (codebergPrMatch) {
-        const [, owner, repo, prNumber] = codebergPrMatch;
-        diffProvider = new CodebergPrDiffProvider(
-          owner,
-          repo.replace(".git", ""),
-          prNumber,
-          env.credentials.codeberg?.token,
-        );
-      } else {
-        diffProvider = new LocalGitDiffProvider(
-          repoRoot,
-          effectiveConfig.git?.baseBranch,
-        );
-      }
+      const diffProvider =
+        t.provider === "github"
+          ? new GitHubPrDiffProvider(t.owner, t.repo, t.pr)
+          : t.provider === "gitlab"
+            ? new GitLabMrDiffProvider(t.group, t.project, t.mr)
+            : t.provider === "codeberg"
+              ? new CodebergPrDiffProvider(
+                  t.owner,
+                  t.repo,
+                  t.pr,
+                  env.credentials.codeberg?.token,
+                )
+              : new LocalGitDiffProvider(
+                  t.root,
+                  effectiveConfig.git?.baseBranch,
+                );
 
       // -------------------------------------------------
       // Run Review Workflow

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -147,11 +147,10 @@ export const reviewCommand = new Command("review")
 
       if (options.autoIndex) {
         try {
-          //TODO: move away from passing raw target here
           await runIndexWorkflow({
             config: effectiveConfig,
             credentials: env.credentials,
-            target,
+            target: t,
             force: false,
             dryRun: false,
             eventBus,
@@ -175,23 +174,32 @@ export const reviewCommand = new Command("review")
 
       console.log("→ Running review...\n");
 
-      const diffProvider =
-        t.provider === "github"
-          ? new GitHubPrDiffProvider(t.owner, t.repo, t.pr)
-          : t.provider === "gitlab"
-            ? new GitLabMrDiffProvider(t.group, t.project, t.mr)
-            : t.provider === "codeberg"
-              ? new CodebergPrDiffProvider(
-                  t.owner,
-                  t.repo,
-                  t.pr,
-                  env.credentials.codeberg?.token,
-                )
-              : new LocalGitDiffProvider(
-                  t.root,
-                  effectiveConfig.git?.baseBranch,
-                );
-
+      const diffProvider = (() => {
+        switch (t.provider) {
+          case "github":
+            if (t.kind !== "pr")
+              throw new Error("Review requires a GitHub PR URL");
+            return new GitHubPrDiffProvider(t.owner, t.repo, t.pr);
+          case "gitlab":
+            if (t.kind !== "mr")
+              throw new Error("Review requires a GitLab MR URL");
+            return new GitLabMrDiffProvider(t.group, t.project, t.mr);
+          case "codeberg":
+            if (t.kind !== "pr")
+              throw new Error("Review requires a Codeberg PR URL");
+            return new CodebergPrDiffProvider(
+              t.owner,
+              t.repo,
+              t.pr,
+              env.credentials.codeberg?.token,
+            );
+          case "filesystem":
+            return new LocalGitDiffProvider(
+              t.root,
+              effectiveConfig.git?.baseBranch,
+            );
+        }
+      })();
       // -------------------------------------------------
       // Run Review Workflow
       // -------------------------------------------------

--- a/apps/cli/src/shared/classifyTarget.ts
+++ b/apps/cli/src/shared/classifyTarget.ts
@@ -2,30 +2,6 @@
 import path from "node:path";
 import { findRepoRoot } from "./findRepoRoot.js";
 
-export type ClassifiedTarget =
-  | {
-      provider: "github";
-      root: string;
-      owner: string;
-      repo: string;
-      pr: string;
-    }
-  | {
-      provider: "gitlab";
-      root: string;
-      group: string;
-      project: string;
-      mr: string;
-    }
-  | {
-      provider: "codeberg";
-      root: string;
-      owner: string;
-      repo: string;
-      pr: string;
-    }
-  | { provider: "filesystem"; root: string };
-
 const GITHUB = /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
 const GITLAB = /gitlab\.com\/([^/]+)\/([^/]+)\/-\/merge_requests\/(\d+)/;
 const CODEBERG = /codeberg\.org\/([^/]+)\/([^/]+)\/pulls\/(\d+)/;

--- a/apps/cli/src/shared/classifyTarget.ts
+++ b/apps/cli/src/shared/classifyTarget.ts
@@ -1,0 +1,67 @@
+// apps/cli/src/shared/classifyTarget.ts
+import path from "node:path";
+import { findRepoRoot } from "./findRepoRoot.js";
+
+export type ClassifiedTarget =
+  | {
+      provider: "github";
+      root: string;
+      owner: string;
+      repo: string;
+      pr: string;
+    }
+  | {
+      provider: "gitlab";
+      root: string;
+      group: string;
+      project: string;
+      mr: string;
+    }
+  | {
+      provider: "codeberg";
+      root: string;
+      owner: string;
+      repo: string;
+      pr: string;
+    }
+  | { provider: "filesystem"; root: string };
+
+const GITHUB = /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
+const GITLAB = /gitlab\.com\/([^/]+)\/([^/]+)\/-\/merge_requests\/(\d+)/;
+const CODEBERG = /codeberg\.org\/([^/]+)\/([^/]+)\/pulls\/(\d+)/;
+
+const stripGit = (s: string) => s.replace(/\.git$/, "");
+
+export function classifyTarget(target: string): ClassifiedTarget {
+  const gh = target.match(GITHUB);
+  if (gh)
+    return {
+      provider: "github",
+      root: target,
+      owner: gh[1]!,
+      repo: stripGit(gh[2]!),
+      pr: gh[3]!,
+    };
+
+  const gl = target.match(GITLAB);
+  if (gl)
+    return {
+      provider: "gitlab",
+      root: target,
+      group: gl[1]!,
+      project: stripGit(gl[2]!),
+      mr: gl[3]!,
+    };
+
+  const cb = target.match(CODEBERG);
+  if (cb)
+    return {
+      provider: "codeberg",
+      root: target,
+      owner: cb[1]!,
+      repo: stripGit(cb[2]!),
+      pr: cb[3]!,
+    };
+
+  return { provider: "filesystem", root: findRepoRoot(path.resolve(target)) };
+}

--- a/apps/cli/src/shared/classifyTarget.ts
+++ b/apps/cli/src/shared/classifyTarget.ts
@@ -1,42 +1,79 @@
 // apps/cli/src/shared/classifyTarget.ts
 import path from "node:path";
+import type { ClassifiedTarget } from "@prsense/core";
 import { findRepoRoot } from "./findRepoRoot.js";
 
-const GITHUB = /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
-const GITLAB = /gitlab\.com\/([^/]+)\/([^/]+)\/-\/merge_requests\/(\d+)/;
-const CODEBERG = /codeberg\.org\/([^/]+)\/([^/]+)\/pulls\/(\d+)/;
+const GITHUB_PR = /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
+const GITLAB_MR = /gitlab\.com\/(.+?)\/([^/]+)\/-\/merge_requests\/(\d+)/;
+const CODEBERG_PR = /codeberg\.org\/([^/]+)\/([^/]+)\/pulls\/(\d+)/;
+const GITHUB_REPO = /github\.com\/([^/]+)\/([^/?#]+?)(?:\.git)?\/?$/;
+const GITLAB_REPO = /gitlab\.com\/(.+?)\/([^/?#]+?)(?:\.git)?\/?$/;
+const CODEBERG_REPO = /codeberg\.org\/([^/]+)\/([^/?#]+?)(?:\.git)?\/?$/;
 
 const stripGit = (s: string) => s.replace(/\.git$/, "");
 
 export function classifyTarget(target: string): ClassifiedTarget {
-  const gh = target.match(GITHUB);
-  if (gh)
+  const ghPr = target.match(GITHUB_PR);
+  if (ghPr)
     return {
       provider: "github",
+      kind: "pr",
       root: target,
-      owner: gh[1]!,
-      repo: stripGit(gh[2]!),
-      pr: gh[3]!,
+      owner: ghPr[1]!,
+      repo: stripGit(ghPr[2]!),
+      pr: ghPr[3]!,
     };
 
-  const gl = target.match(GITLAB);
-  if (gl)
+  const glMr = target.match(GITLAB_MR);
+  if (glMr)
     return {
       provider: "gitlab",
+      kind: "mr",
       root: target,
-      group: gl[1]!,
-      project: stripGit(gl[2]!),
-      mr: gl[3]!,
+      group: glMr[1]!,
+      project: stripGit(glMr[2]!),
+      mr: glMr[3]!,
     };
 
-  const cb = target.match(CODEBERG);
-  if (cb)
+  const cbPr = target.match(CODEBERG_PR);
+  if (cbPr)
     return {
       provider: "codeberg",
+      kind: "pr",
       root: target,
-      owner: cb[1]!,
-      repo: stripGit(cb[2]!),
-      pr: cb[3]!,
+      owner: cbPr[1]!,
+      repo: stripGit(cbPr[2]!),
+      pr: cbPr[3]!,
+    };
+
+  const ghRepo = target.match(GITHUB_REPO);
+  if (ghRepo)
+    return {
+      provider: "github",
+      kind: "repo",
+      root: target,
+      owner: ghRepo[1]!,
+      repo: stripGit(ghRepo[2]!),
+    };
+
+  const glRepo = target.match(GITLAB_REPO);
+  if (glRepo)
+    return {
+      provider: "gitlab",
+      kind: "repo",
+      root: target,
+      group: glRepo[1]!,
+      project: stripGit(glRepo[2]!),
+    };
+
+  const cbRepo = target.match(CODEBERG_REPO);
+  if (cbRepo)
+    return {
+      provider: "codeberg",
+      kind: "repo",
+      root: target,
+      owner: cbRepo[1]!,
+      repo: stripGit(cbRepo[2]!),
     };
 
   return { provider: "filesystem", root: findRepoRoot(path.resolve(target)) };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prsense-meta",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "private": true,
   "description": "Code reviewer that surfaces high risk signals from diff",
   "main": "index.js",

--- a/packages/core/src/IndexedRepository.ts
+++ b/packages/core/src/IndexedRepository.ts
@@ -1,3 +1,4 @@
+// packages/core/src/IndexedRepository.ts
 export type IndexedRepository = {
   provider: string;
   repository: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,4 @@ export * from "./IndexedRepository.js";
 export * from "./paths.js";
 
 export * from "./llm/EmbeddingClient.js";
+export * from "./repository/target.js";

--- a/packages/core/src/repository/target.ts
+++ b/packages/core/src/repository/target.ts
@@ -2,23 +2,47 @@
 export type ClassifiedTarget =
   | {
       provider: "github";
+      kind: "pr";
       root: string;
       owner: string;
       repo: string;
       pr: string;
     }
   | {
+      provider: "github";
+      kind: "repo";
+      root: string;
+      owner: string;
+      repo: string;
+    }
+  | {
       provider: "gitlab";
+      kind: "mr";
       root: string;
       group: string;
       project: string;
       mr: string;
     }
   | {
+      provider: "gitlab";
+      kind: "repo";
+      root: string;
+      group: string;
+      project: string;
+    }
+  | {
       provider: "codeberg";
+      kind: "pr";
       root: string;
       owner: string;
       repo: string;
       pr: string;
+    }
+  | {
+      provider: "codeberg";
+      kind: "repo";
+      root: string;
+      owner: string;
+      repo: string;
     }
   | { provider: "filesystem"; root: string };

--- a/packages/core/src/repository/target.ts
+++ b/packages/core/src/repository/target.ts
@@ -1,0 +1,24 @@
+// packages/core/src/repository/target.ts
+export type ClassifiedTarget =
+  | {
+      provider: "github";
+      root: string;
+      owner: string;
+      repo: string;
+      pr: string;
+    }
+  | {
+      provider: "gitlab";
+      root: string;
+      group: string;
+      project: string;
+      mr: string;
+    }
+  | {
+      provider: "codeberg";
+      root: string;
+      owner: string;
+      repo: string;
+      pr: string;
+    }
+  | { provider: "filesystem"; root: string };

--- a/packages/workflows/src/index/__tests__/incremental.test.ts
+++ b/packages/workflows/src/index/__tests__/incremental.test.ts
@@ -38,7 +38,7 @@ describe("Incremental indexing (real DB)", () => {
     overrides: Partial<Parameters<typeof runIndexWorkflow>[0]> = {},
   ) =>
     runIndexWorkflow({
-      target: repo,
+      target: { provider: "filesystem", root: repo },
       config: testConfig(),
       credentials: testCredentials(),
       eventBus: overrides.eventBus ?? new TestEventBus(),

--- a/packages/workflows/src/index/__tests__/incrementalAstChunking.test.ts
+++ b/packages/workflows/src/index/__tests__/incrementalAstChunking.test.ts
@@ -35,7 +35,7 @@ describe("AST chunking through index workflow (real DB)", () => {
     overrides: Partial<Parameters<typeof runIndexWorkflow>[0]> = {},
   ) =>
     runIndexWorkflow({
-      target: repo,
+      target: { provider: "filesystem", root: repo },
       config: testConfig(),
       credentials: testCredentials(),
       eventBus: overrides.eventBus ?? new TestEventBus(),

--- a/packages/workflows/src/index/indexWorkflow.ts
+++ b/packages/workflows/src/index/indexWorkflow.ts
@@ -1,5 +1,10 @@
 // packages/workflows/src/index/indexWorkflow.ts
-import { CoreEvents, EventBus, ContextChunk } from "@prsense/core";
+import {
+  CoreEvents,
+  EventBus,
+  ContextChunk,
+  ClassifiedTarget,
+} from "@prsense/core";
 import {
   createCompositeChunker,
   IndexMetadataRepository,
@@ -37,7 +42,7 @@ export async function runIndexWorkflow({
 }: {
   config: ResolvedConfig;
   credentials: CredentialContext;
-  target: string;
+  target: ClassifiedTarget;
   force?: boolean;
   dryRun?: boolean;
   eventBus: EventBus;

--- a/packages/workflows/src/index/util.ts
+++ b/packages/workflows/src/index/util.ts
@@ -1,8 +1,10 @@
 // packages/workflows/src/index/util.ts
 import { execFileSync } from "node:child_process";
-
-import path from "node:path";
-import type { IndexMetadata, ContextChunk } from "@prsense/core";
+import type {
+  IndexMetadata,
+  ContextChunk,
+  ClassifiedTarget,
+} from "@prsense/core";
 import { EventBus, CoreEvents } from "@prsense/core";
 
 import type { IndexPlan, ExecutionPlan } from "./types.js";
@@ -17,41 +19,21 @@ import {
   RefAwareRepositorySource,
 } from "@prsense/context";
 
-export function resolveRepositorySource(target: string, ref?: string) {
-  const isGithub = /github\.com/.test(target);
-  const isGitlab = /gitlab\.com/.test(target);
-
-  if (isGithub) {
-    const match = target.match(/github\.com\/([^\/]+)\/([^\/]+)/);
-
-    if (!match) {
-      throw new Error("Invalid GitHub URL");
+export function resolveRepositorySource(
+  target: ClassifiedTarget,
+  ref?: string,
+) {
+  switch (target.provider) {
+    case "github":
+      return new GitHubRepositorySource(target.owner, target.repo);
+    case "gitlab":
+      return new GitLabRepositorySource(target.group, target.project);
+    case "codeberg":
+      throw new Error("Codeberg indexing not yet wired"); // follow-up PR
+    case "filesystem": {
+      const src = new FileSystemRepositorySource(target.root);
+      return ref ? new RefAwareRepositorySource(src, ref) : src;
     }
-
-    const owner = match[1];
-    const repo = match[2];
-
-    if (!owner || !repo) {
-      throw new Error("Invalid GitHub repository url");
-    }
-
-    return new GitHubRepositorySource(owner, repo.replace(".git", ""));
-  } else if (isGitlab) {
-    const match = target.match(/gitlab\.com\/(.+?)\/([^\/]+)(?:\.git)?$/);
-
-    if (!match) throw new Error("Invalid GitLab URL");
-
-    const owner = match[1];
-    const repo = match[2];
-    if (!owner || !repo) throw new Error("Invalid GitLab repository url");
-    return new GitLabRepositorySource(owner, repo.replace(".git", ""));
-  } else {
-    const absolute = path.resolve(target);
-    let repositorySource = new FileSystemRepositorySource(absolute);
-    if (ref) {
-      return new RefAwareRepositorySource(repositorySource, ref);
-    }
-    return repositorySource;
   }
 }
 

--- a/packages/workflows/src/review/__tests__/contextExclusion.test.ts
+++ b/packages/workflows/src/review/__tests__/contextExclusion.test.ts
@@ -30,7 +30,7 @@ describe("RAG retrieval excludes diff-modified files (option A)", () => {
 
   const indexRepo = () =>
     runIndexWorkflow({
-      target: repo,
+      target: { provider: "filesystem", root: repo },
       config: testConfig(),
       credentials: testCredentials(),
       force: true,
@@ -56,7 +56,10 @@ describe("RAG retrieval excludes diff-modified files (option A)", () => {
     await indexRepo();
 
     // Use the same identity the indexer wrote with
-    const identity = resolveRepositorySource(repo).getRepositoryIdentity();
+    const identity = resolveRepositorySource({
+      provider: "filesystem",
+      root: repo,
+    }).getRepositoryIdentity();
 
     const retrieved = await retrieveContext({
       config: testConfig(),
@@ -81,7 +84,10 @@ describe("RAG retrieval excludes diff-modified files (option A)", () => {
 
     await indexRepo();
 
-    const identity = resolveRepositorySource(repo).getRepositoryIdentity();
+    const identity = resolveRepositorySource({
+      provider: "filesystem",
+      root: repo,
+    }).getRepositoryIdentity();
 
     const retrieved = await retrieveContext({
       config: testConfig(),


### PR DESCRIPTION
Currently repository root / target determination is broken, especially for monorepositories. This PR issues a refactor of the shared logic between all commands to identify the target / repository providers